### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [More information about CockroachDB](https://www.cockroachlabs.com/)
 - [More information about Terraform](https://terraform.io)
 
-For information on developing `terraform-proivder-cockroach` see [DEVELOPMENT.md](DEVELOPMENT.md).
+For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 **Note: This is a preview release, suitable only for experimental use.**
 


### PR DESCRIPTION
s/terraform-proivder-cockroach/terraform-provider-cockroach

* [N/A] I have added these changes to the changelog (or it's not applicable).
