### PR TITLE
Correcting 0.3.2 version in Makefile and fixing provider path in workflow examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=registry.terraform.io
 NAMESPACE=hashicorp
 NAME=cockroach
 BINARY=terraform-provider-${NAME}
-VERSION=0.3.2
+VERSION=0.1.1
 OS_ARCH=darwin_amd64
 
 default: install

--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -64,9 +64,12 @@ variable cidr_mask {
 terraform {
   required_providers {
     cockroach = {
-      source = "registry.terraform.io/hashicorp/cockroach"
+      source = "cockroachdb/cockroach"
     }
   }
+}
+provider "cockroach" {
+  # Configuration options
 }
 provider "cockroach" {
 # export COCKROACH_API_KEY with the cockroach cloud API Key

--- a/examples/workflows/cockroach_serverless_cluster/main.tf
+++ b/examples/workflows/cockroach_serverless_cluster/main.tf
@@ -36,7 +36,7 @@ variable "cloud_provider_region" {
 terraform {
   required_providers {
     cockroach = {
-      source = "registry.terraform.io/hashicorp/cockroach"
+      source = "cockroachdb/cockroach"
     }
   }
 }


### PR DESCRIPTION
- Correcting 0.3.2 version in Makefile
- fixing incorrect path for provider in workflow examples

_Add a description of the problem this PR addresses and an overview of how this PR works_.

Our workflow examples call for path "hashicorp/cockroach" but the registry page points to a different path "cockroachdb/cockroach". Somehow the version obtained via the incorrect path is 0.3.2 - i'm guessing it's getting that version from the Makefile, which specifies version 0.3.2.

If one uses the correct path, the correct version is shown in `terraform init` - so the change to the Makefile may be unnecessary. 

<img width="443" alt="image" src="https://user-images.githubusercontent.com/193360/193117623-7c057b21-d043-4b92-89ad-ca033c8d0dac.png">

<img width="391" alt="image" src="https://user-images.githubusercontent.com/193360/193117915-b043a331-aaaf-4249-ad20-0511e56d0af8.png">



**Checklist**

* [ ] I have added these changes to the changelog (or it's not applicable).
