### PR TITLE
Update to Go SDK v0.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# IDE project files
+.idea/
+.vscode/
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cockroachdb/terraform-provider-cockroach
 go 1.17
 
 require (
-	github.com/cockroachdb/cockroach-cloud-sdk-go v0.2.0
+	github.com/cockroachdb/cockroach-cloud-sdk-go v0.3.1
 	github.com/hashicorp/terraform-plugin-docs v0.7.0
 	github.com/hashicorp/terraform-plugin-framework v0.8.0
 	github.com/hashicorp/terraform-plugin-go v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/cockroach-cloud-sdk-go v0.2.0 h1:y+sh6+bcpdGC8nbkobrZBg9kNpyZS7sskJOSU3lbVZI=
 github.com/cockroachdb/cockroach-cloud-sdk-go v0.2.0/go.mod h1:zVVtMKMcPkwrYgrZ/hv73HiGSsWId3BorWlSpRWc7tM=
+github.com/cockroachdb/cockroach-cloud-sdk-go v0.3.1 h1:PaqggGcqDV8/T9AQMXzSC+xjhtLo92eDpqLi76yIeNg=
+github.com/cockroachdb/cockroach-cloud-sdk-go v0.3.1/go.mod h1:zVVtMKMcPkwrYgrZ/hv73HiGSsWId3BorWlSpRWc7tM=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -27,9 +27,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
-type networkResourceType struct{}
+type allowListResourceType struct{}
 
-func (n networkResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+func (n allowListResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		MarkdownDescription: "Allow list of IP range",
 		Attributes: map[string]tfsdk.Attribute{
@@ -61,19 +61,19 @@ func (n networkResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.
 	}, nil
 }
 
-func (n networkResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (n allowListResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
-	return networkResource{
+	return allowListResource{
 		provider: provider,
 	}, diags
 }
 
-type networkResource struct {
+type allowListResource struct {
 	provider provider
 }
 
-func (n networkResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
+func (n allowListResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	if !n.provider.configured {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
@@ -134,7 +134,7 @@ func (n networkResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 	}
 }
 
-func (n networkResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
+func (n allowListResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
 	if !n.provider.configured {
 		resp.Diagnostics.AddError(
 			"Provider not configured",
@@ -152,7 +152,7 @@ func (n networkResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	}
 }
 
-func (n networkResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
+func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
 	// Get plan values
 	var plan AllowlistEntry
 	diags := req.Plan.Get(ctx, &plan)
@@ -181,12 +181,10 @@ func (n networkResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 	entryCIDRIp := plan.CidrIp.Value
 	entryCIDRMask := int32(plan.CidrMask.Value)
 
-	existingAllowList := client.AllowlistEntry{
-		CidrIp:   state.CidrIp.Value,
-		CidrMask: int32(state.CidrMask.Value),
-		Ui:       state.Ui.Value,
-		Sql:      state.Sql.Value,
-		Name:     &state.Name.Value,
+	existingAllowList := client.AllowlistEntry1{
+		Ui:   state.Ui.Value,
+		Sql:  state.Sql.Value,
+		Name: &state.Name.Value,
 	}
 
 	_, httpResp, err := n.provider.service.UpdateAllowlistEntry(ctx, clusterId, entryCIDRIp, entryCIDRMask,
@@ -206,7 +204,7 @@ func (n networkResource) Update(ctx context.Context, req tfsdk.UpdateResourceReq
 	}
 }
 
-func (n networkResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
+func (n allowListResource) Delete(ctx context.Context, req tfsdk.DeleteResourceRequest, resp *tfsdk.DeleteResourceResponse) {
 	var state AllowlistEntry
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -227,6 +225,6 @@ func (n networkResource) Delete(ctx context.Context, req tfsdk.DeleteResourceReq
 	resp.State.RemoveResource(ctx)
 }
 
-func (n networkResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
+func (n allowListResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
 	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -98,7 +98,7 @@ func (p *provider) GetResources(ctx context.Context) (map[string]tfsdk.ResourceT
 	return map[string]tfsdk.ResourceType{
 		"cockroach_cluster":    clusterResourceType{},
 		"cockroach_sql_user":   sqlUserResourceType{},
-		"cockroach_allow_list": networkResourceType{},
+		"cockroach_allow_list": allowListResourceType{},
 	}, nil
 }
 


### PR DESCRIPTION
- Updated the CCAPI client library to v0.3.1.
- Renamed "networkResource" to "allowListResource" to avoid ambiguity with other resources, such as PrivateLink specs.
- Updated the UpdateAllowList input to match new simplified format.

No user-facing changes. This just paves the way for new resources to be added later.

Ran the examples and verified they still work.