### PR TITLE
Clean up SQL User and Allowlist resources

### DIFF
--- a/docs/resources/allow_list.md
+++ b/docs/resources/allow_list.md
@@ -19,15 +19,12 @@ Allow list of IP range
 
 - `cidr_ip` (String)
 - `cidr_mask` (Number)
+- `cluster_id` (String)
 - `sql` (Boolean)
 - `ui` (Boolean)
 
 ### Optional
 
 - `name` (String)
-
-### Read-Only
-
-- `id` (String) The ID of this resource.
 
 

--- a/docs/resources/sql_user.md
+++ b/docs/resources/sql_user.md
@@ -17,11 +17,8 @@ SQL user and password
 
 ### Required
 
+- `cluster_id` (String)
 - `name` (String)
 - `password` (String, Sensitive)
-
-### Read-Only
-
-- `id` (String) The ID of this resource.
 
 

--- a/examples/resources/cockroach_ip_allowlist/cockroach_ip_allowlist.tf
+++ b/examples/resources/cockroach_ip_allowlist/cockroach_ip_allowlist.tf
@@ -3,10 +3,10 @@ variable "cluster_id" {
 }
 
 resource "cockroach_allow_list" "cockroach" {
-  name      = "example-allow-list"
-  cidr_ip   = "192.168.1.1"
-  cidr_mask = 32
-  ui        = true
-  sql       = true
-  id        = var.cluster_id
+  name       = "example-allow-list"
+  cidr_ip    = "192.168.1.1"
+  cidr_mask  = 32
+  ui         = true
+  sql        = true
+  cluster_id = var.cluster_id
 }

--- a/examples/resources/cockroach_sql_user/cockroach_sql_user.tf
+++ b/examples/resources/cockroach_sql_user/cockroach_sql_user.tf
@@ -7,7 +7,7 @@ variable "sql_user_password" {
 }
 
 resource "cockroach_sql_user" "cockroach" {
-  name     = "example-sql-user"
-  password = var.sql_user_password
-  id       = var.cluster_id
+  name       = "example-sql-user"
+  password   = var.sql_user_password
+  cluster_id = var.cluster_id
 }

--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -88,18 +88,18 @@ resource "cockroach_cluster" "cockroach" {
 }
 
 resource "cockroach_allow_list" "cockroach" {
-  name      = var.allow_list_name
-  cidr_ip   = var.cidr_ip
-  cidr_mask = var.cidr_mask
-  ui        = true
-  sql       = true
-  id        = cockroach_cluster.cockroach.id
+  name       = var.allow_list_name
+  cidr_ip    = var.cidr_ip
+  cidr_mask  = var.cidr_mask
+  ui         = true
+  sql        = true
+  cluster_id = cockroach_cluster.cockroach.id
 }
 
 resource "cockroach_sql_user" "cockroach" {
-  name     = var.sql_user_name
-  password = var.sql_user_password
-  id       = cockroach_cluster.cockroach.id
+  name       = var.sql_user_name
+  password   = var.sql_user_password
+  cluster_id = cockroach_cluster.cockroach.id
 }
 
 data "cockroach_cluster" "cockroach" {

--- a/examples/workflows/cockroach_serverless_cluster/main.tf
+++ b/examples/workflows/cockroach_serverless_cluster/main.tf
@@ -54,7 +54,7 @@ resource "cockroach_cluster" "cockroach" {
 }
 
 resource "cockroach_sql_user" "cockroach" {
-  name     = var.sql_user_name
-  password = var.sql_user_password
-  id       = cockroach_cluster.cockroach.id
+  name       = var.sql_user_name
+  password   = var.sql_user_password
+  cluster_id = cockroach_cluster.cockroach.id
 }

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -222,10 +222,7 @@ type clusterResource struct {
 
 func (r clusterResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	if !r.provider.configured {
-		resp.Diagnostics.AddError(
-			"Provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 
@@ -339,10 +336,7 @@ func (r clusterResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 
 func (r clusterResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
 	if !r.provider.configured {
-		resp.Diagnostics.AddError(
-			"provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -52,15 +52,11 @@ type ServerlessClusterConfig struct {
 	RoutingId  types.String `tfsdk:"routing_id"`
 }
 
-// SQLUserSpecification struct for SQLUserSpecification.
-type SQLUserSpecification struct {
-	Id       types.String `tfsdk:"id"`
-	Name     types.String `tfsdk:"name"`
-	Password types.String `tfsdk:"password"`
-}
-
 type SQLUser struct {
-	Name types.String `tfsdk:"name"`
+	ClusterId types.String `tfsdk:"cluster_id"`
+	Name      types.String `tfsdk:"name"`
+	Password  types.String `tfsdk:"password"`
+	ID        types.String `tfsdk:"id"`
 }
 
 type APIErrorMessage struct {
@@ -86,12 +82,13 @@ type CockroachCluster struct {
 
 // AllowlistEntry struct for AllowlistEntry.
 type AllowlistEntry struct {
-	Id       types.String `tfsdk:"id"`
-	CidrIp   types.String `tfsdk:"cidr_ip"`
-	CidrMask types.Int64  `tfsdk:"cidr_mask"`
-	Ui       types.Bool   `tfsdk:"ui"`
-	Sql      types.Bool   `tfsdk:"sql"`
-	Name     types.String `tfsdk:"name"`
+	ClusterId types.String `tfsdk:"cluster_id"`
+	CidrIp    types.String `tfsdk:"cidr_ip"`
+	CidrMask  types.Int64  `tfsdk:"cidr_mask"`
+	Ui        types.Bool   `tfsdk:"ui"`
+	Sql       types.Bool   `tfsdk:"sql"`
+	Name      types.String `tfsdk:"name"`
+	ID        types.String `tfsdk:"id"`
 }
 
 func (e *APIErrorMessage) String() string {

--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -75,10 +75,7 @@ type allowListResource struct {
 
 func (n allowListResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	if !n.provider.configured {
-		resp.Diagnostics.AddError(
-			"Provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 
@@ -136,10 +133,7 @@ func (n allowListResource) Create(ctx context.Context, req tfsdk.CreateResourceR
 
 func (n allowListResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
 	if !n.provider.configured {
-		resp.Diagnostics.AddError(
-			"Provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 

--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -19,21 +19,28 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 type allowListResourceType struct{}
 
-func (n allowListResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, diag.Diagnostics) {
+// clusterID:ip/mask
+const allowListIDFmt = "%s:%s/%d"
+const allowlistEntryRegex = `(([0-9]{1,3}\.){3}[0-9]{1,3})\/([0-9]|[1-2][0-9]|3[0-2])`
+
+var allowlistIDRegex = regexp.MustCompile(fmt.Sprintf("^(%s):%s$", uuidRegex, allowlistEntryRegex))
+
+func (n allowListResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		MarkdownDescription: "Allow list of IP range",
 		Attributes: map[string]tfsdk.Attribute{
-			"id": {
+			"cluster_id": {
 				Required: true,
 				Type:     types.StringType,
 			},
@@ -57,11 +64,18 @@ func (n allowListResourceType) GetSchema(ctx context.Context) (tfsdk.Schema, dia
 				Optional: true,
 				Type:     types.StringType,
 			},
+			"id": {
+				Computed: true,
+				Type:     types.StringType,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.UseStateForUnknown(),
+				},
+			},
 		},
 	}, nil
 }
 
-func (n allowListResourceType) NewResource(ctx context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
+func (n allowListResourceType) NewResource(_ context.Context, in tfsdk.Provider) (tfsdk.Resource, diag.Diagnostics) {
 	provider, diags := convertProviderType(in)
 
 	return allowListResource{
@@ -79,19 +93,24 @@ func (n allowListResource) Create(ctx context.Context, req tfsdk.CreateResourceR
 		return
 	}
 
-	var plan AllowlistEntry
-	diags := req.Config.Get(ctx, &plan)
+	var entry AllowlistEntry
+	diags := req.Config.Get(ctx, &entry)
 	resp.Diagnostics.Append(diags...)
+	// Create a unique ID (required by terraform framework) by combining
+	// the cluster ID and full CIDR address.
+	entry.ID = types.String{
+		Value: fmt.Sprintf(allowListIDFmt, entry.ClusterId.Value, entry.CidrIp.Value, entry.CidrMask.Value),
+	}
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	cluster, httpResp, err := n.provider.service.GetCluster(ctx, plan.Id.Value)
+	cluster, _, err := n.provider.service.GetCluster(ctx, entry.ClusterId.Value)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error getting the cluster",
-			fmt.Sprintf("Could not get the cluster, unexpected error: %v %v "+err.Error(), httpResp),
+			fmt.Sprintf("Could not get the cluster, unexpected error: %v", err.Error()),
 		)
 		return
 	}
@@ -99,32 +118,32 @@ func (n allowListResource) Create(ctx context.Context, req tfsdk.CreateResourceR
 	if cluster.Config.Serverless != nil {
 		resp.Diagnostics.AddError(
 			"Could not add network allow list in serverless cluster",
-			fmt.Sprintf("Network allow list is a feature of dedicated cluster, unexpected error: %v %v "+err.Error(), httpResp),
+			fmt.Sprintf("Network allow list is a feature of dedicated cluster, unexpected error: %v", err.Error()),
 		)
 		return
 	}
 
 	var allowList = client.AllowlistEntry{
-		CidrIp:   plan.CidrIp.Value,
-		CidrMask: int32(plan.CidrMask.Value),
-		Ui:       plan.Ui.Value,
-		Sql:      plan.Sql.Value,
+		CidrIp:   entry.CidrIp.Value,
+		CidrMask: int32(entry.CidrMask.Value),
+		Ui:       entry.Ui.Value,
+		Sql:      entry.Sql.Value,
 	}
 
-	if !plan.Name.Null {
-		allowList.Name = &plan.Name.Value
+	if !entry.Name.Null {
+		allowList.Name = &entry.Name.Value
 	}
 
-	_, httpResp, err = n.provider.service.AddAllowlistEntry(ctx, plan.Id.Value, &allowList)
+	_, _, err = n.provider.service.AddAllowlistEntry(ctx, entry.ClusterId.Value, &allowList)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error adding allowed IP range",
-			fmt.Sprintf("Could not add allowed IP range, unexpected error: %v %v "+err.Error(), httpResp),
+			fmt.Sprintf("Could not add allowed IP range, unexpected error: %v", err.Error()),
 		)
 		return
 	}
 
-	diags = resp.State.Set(ctx, plan)
+	diags = resp.State.Set(ctx, entry)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -137,13 +156,36 @@ func (n allowListResource) Read(ctx context.Context, req tfsdk.ReadResourceReque
 		return
 	}
 
-	var plan AllowlistEntry
-	diags := req.State.Get(ctx, &plan)
+	var state AllowlistEntry
+	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// Since the state may have come from an import, we need to retrieve
+	// the actual entry list and make sure this one is in there.
+	apiResp, _, err := n.provider.service.ListAllowlistEntries(ctx, state.ClusterId.Value, &client.ListAllowlistEntriesOptions{})
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Couldn't retrieve allowlist entries",
+			fmt.Sprintf("Unexpected error retrieving allowlist entries: %v", err.Error()),
+		)
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	for _, entry := range apiResp.GetAllowlist() {
+		if entry.GetCidrIp() == state.CidrIp.Value ||
+			int64(entry.GetCidrMask()) == state.CidrMask.Value {
+			return
+		}
+	}
+	resp.Diagnostics.AddError(
+		"Couldn't find entry.",
+		fmt.Sprintf("This cluster's allowlist doesn't contain %s/%d", state.CidrIp.Value, state.CidrMask.Value),
+	)
 }
 
 func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {
@@ -163,7 +205,7 @@ func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceR
 		return
 	}
 
-	if state.Id != plan.Id {
+	if state.ClusterId != plan.ClusterId {
 		resp.Diagnostics.AddError(
 			"can not change cluster id in the network allow list",
 			"You can only change network allow list. Thanks!",
@@ -171,7 +213,7 @@ func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceR
 		return
 	}
 
-	clusterId := plan.Id.Value
+	clusterId := plan.ClusterId.Value
 	entryCIDRIp := plan.CidrIp.Value
 	entryCIDRMask := int32(plan.CidrMask.Value)
 
@@ -181,12 +223,12 @@ func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceR
 		Name: &state.Name.Value,
 	}
 
-	_, httpResp, err := n.provider.service.UpdateAllowlistEntry(ctx, clusterId, entryCIDRIp, entryCIDRMask,
+	_, _, err := n.provider.service.UpdateAllowlistEntry(ctx, clusterId, entryCIDRIp, entryCIDRMask,
 		&existingAllowList, &client.UpdateAllowlistEntryOptions{})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error updating network allow list",
-			fmt.Sprintf("Could not update network allow list, unexpected error: %v %v "+err.Error(), httpResp),
+			fmt.Sprintf("Could not update network allow list, unexpected error: %v", err.Error()),
 		)
 		return
 	}
@@ -206,11 +248,11 @@ func (n allowListResource) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 		return
 	}
 
-	_, httpResp, err := n.provider.service.DeleteAllowlistEntry(ctx, state.Id.Value, state.CidrIp.Value, int32(state.CidrMask.Value))
+	_, _, err := n.provider.service.DeleteAllowlistEntry(ctx, state.ClusterId.Value, state.CidrIp.Value, int32(state.CidrMask.Value))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting network allow list",
-			fmt.Sprintf("Could not delete network allow list, unexpected error: %v %v "+err.Error(), httpResp),
+			fmt.Sprintf("Could not delete network allow list, unexpected error: %v", err.Error()),
 		)
 		return
 	}
@@ -220,5 +262,23 @@ func (n allowListResource) Delete(ctx context.Context, req tfsdk.DeleteResourceR
 }
 
 func (n allowListResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("id"), req, resp)
+	// Since an allowlist entry is uniquely identified by three fields: the cluster ID,
+	// CIDR IP, and CIDR mask, and we serialize them all into the ID field. To make import
+	// work, we need to deserialize an ID back into its components.
+	var mask int
+	matches := allowlistIDRegex.FindStringSubmatch(req.ID)
+	if len(matches) != 5 {
+		resp.Diagnostics.AddError(
+			"Invalid allowlist entry ID format",
+			`When importing an allowlist entry, the ID field should follow the format "<cluster ID>:<CIDR IP>/<CIDR mask>")`)
+	}
+	// We can swallow this error because it's already been regex-validated.
+	mask, _ = strconv.Atoi(matches[4])
+	entry := AllowlistEntry{
+		ClusterId: types.String{Value: matches[1]},
+		CidrIp:    types.String{Value: matches[2]},
+		CidrMask:  types.Int64{Value: int64(mask)},
+		ID:        types.String{Value: req.ID},
+	}
+	resp.Diagnostics = resp.State.Set(ctx, &entry)
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -36,10 +36,12 @@ var cl *client.Client
 func init() {
 	apikey := os.Getenv(CockroachAPIKey)
 	cfg := client.NewConfiguration(apikey)
+	if server := os.Getenv(APIServerURLKey); server != "" {
+		cfg.ServerURL = server
+	}
 	cfg.UserAgent = UserAgent
 	cl = client.NewClient(cfg)
 	testAccProvider = New("test")()
-
 }
 
 // testAccProtoV6ProviderFactories are used to instantiate a provider during

--- a/internal/provider/sql_user_resource.go
+++ b/internal/provider/sql_user_resource.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"fmt"
+
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -63,10 +64,7 @@ type sqlUserResource struct {
 
 func (s sqlUserResource) Create(ctx context.Context, req tfsdk.CreateResourceRequest, resp *tfsdk.CreateResourceResponse) {
 	if !s.provider.configured {
-		resp.Diagnostics.AddError(
-			"Provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 
@@ -109,10 +107,7 @@ func (s sqlUserResource) Create(ctx context.Context, req tfsdk.CreateResourceReq
 
 func (s sqlUserResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest, resp *tfsdk.ReadResourceResponse) {
 	if !s.provider.configured {
-		resp.Diagnostics.AddError(
-			"provider not configured",
-			"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
-		)
+		addConfigureProviderErr(&resp.Diagnostics)
 		return
 	}
 

--- a/internal/provider/sql_user_resource_test.go
+++ b/internal/provider/sql_user_resource_test.go
@@ -68,10 +68,11 @@ func testAccSqlUserExists(resourceName, clusterResourceName string) resource.Tes
 			return fmt.Errorf("no ID is set")
 		}
 
-		id := clusterRs.Primary.Attributes["id"]
+		clusterID := clusterRs.Primary.Attributes["id"]
 		log.Printf("[DEBUG] clusterID: %s, name %s", clusterRs.Primary.Attributes["id"], clusterRs.Primary.Attributes["name"])
 
-		if clusterResp, _, err := p.service.ListSQLUsers(context.TODO(), id, &listUserOptions); err == nil {
+		clusterResp, _, err := p.service.ListSQLUsers(context.TODO(), clusterID, &listUserOptions)
+		if err == nil {
 			for _, user := range clusterResp.Users {
 				if user.GetName() == rs.Primary.Attributes["name"] {
 					return nil
@@ -79,7 +80,7 @@ func testAccSqlUserExists(resourceName, clusterResourceName string) resource.Tes
 			}
 		}
 
-		return fmt.Errorf("cluster(%s:%s) does not exist", rs.Primary.Attributes["id"], rs.Primary.ID)
+		return fmt.Errorf("user %s does not exist", rs.Primary.ID)
 	}
 }
 
@@ -100,7 +101,7 @@ resource "cockroach_cluster" "serverless" {
 resource "cockroach_sql_user" "sqluser" {
   name = "%s"
   password = "%s"
-  id = cockroach_cluster.serverless.id
+  cluster_id = cockroach_cluster.serverless.id
 }
 `, clusterName, name, password)
 }

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -1,0 +1,10 @@
+package provider
+
+import "github.com/hashicorp/terraform-plugin-framework/diag"
+
+func addConfigureProviderErr(diagnostics *diag.Diagnostics) {
+	diagnostics.AddError(
+		"Provider not configured",
+		"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
+	)
+}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -8,3 +8,5 @@ func addConfigureProviderErr(diagnostics *diag.Diagnostics) {
 		"The provider hasn't been configured before apply, likely because it depends on an unknown value from another resource. This leads to weird stuff happening, so we'd prefer if you didn't do that. Thanks!",
 	)
 }
+
+const uuidRegex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"


### PR DESCRIPTION
- Fixed import by composing a unique ID for both resources
- Renamed the old id to cluster_id
- Implemented Read with an API call instead of copying the state
- Cleaned up error message formatting
- Updated test provider to use COCKROACH_SERVER
- Consolidated SQL user models
- Reran `go generate`
- Pull misconfigured provider error into util function