### PR TITLE
Force allowlist rebuild when address is changed

### DIFF
--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -47,10 +47,16 @@ func (n allowListResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.
 			"cidr_ip": {
 				Required: true,
 				Type:     types.StringType,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.RequiresReplace(),
+				},
 			},
 			"cidr_mask": {
 				Required: true,
 				Type:     types.Int64Type,
+				PlanModifiers: tfsdk.AttributePlanModifiers{
+					tfsdk.RequiresReplace(),
+				},
 			},
 			"ui": {
 				Required: true,


### PR DESCRIPTION
Since the ID is based on the CIDR address, it needs to be recomputed when the address is updated.
