### PR TITLE
Fixed endpoint connection import and annotated example

### DIFF
--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -23,7 +23,7 @@ AWS PrivateLink Endpoint Connection
 ### Read-Only
 
 - `cloud_provider` (String)
-- `id` (String) Required by Terraform. Will always equal endpoint_id.
+- `id` (String) Used with `terrform import`. Format is "<cluster ID>:<endpoint ID>"
 - `region_name` (String)
 - `service_id` (String)
 

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -20,25 +20,30 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 type privateEndpointConnectionResourceType struct{}
+
+// clusterID:endpointID
+const privateEndpointConnectionIDFmt = "%s:%s"
+
+var privateEndpointConnectionIDRegex = regexp.MustCompile(fmt.Sprintf("^(%s):(.*)$", uuidRegex))
 
 func (r privateEndpointConnectionResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
 		MarkdownDescription: "AWS PrivateLink Endpoint Connection",
 		Attributes: map[string]tfsdk.Attribute{
 			"id": {
-				Computed:    true,
-				Type:        types.StringType,
-				Description: "Required by Terraform. Will always equal endpoint_id.",
+				Computed:            true,
+				Type:                types.StringType,
+				MarkdownDescription: "Used with `terrform import`. Format is \"<cluster ID>:<endpoint ID>\"",
 				PlanModifiers: tfsdk.AttributePlanModifiers{
 					tfsdk.UseStateForUnknown(),
 				},
@@ -202,7 +207,12 @@ func (r privateEndpointConnectionResource) Read(ctx context.Context, req tfsdk.R
 
 func loadEndpointConnectionIntoTerraformState(apiConnection *client.AwsEndpointConnection, state *PrivateEndpointConnection) {
 	state.EndpointID = types.String{Value: apiConnection.GetEndpointId()}
-	state.ID = types.String{Value: apiConnection.GetEndpointId()}
+	state.ID = types.String{
+		Value: fmt.Sprintf(
+			privateEndpointConnectionIDFmt,
+			state.ClusterID.Value,
+			apiConnection.GetEndpointId()),
+	}
 	state.ServiceID = types.String{Value: apiConnection.GetServiceId()}
 	state.CloudProvider = types.String{Value: string(apiConnection.GetCloudProvider())}
 	state.RegionName = types.String{Value: apiConnection.GetRegionName()}
@@ -238,7 +248,25 @@ func (r privateEndpointConnectionResource) Delete(ctx context.Context, req tfsdk
 }
 
 func (r privateEndpointConnectionResource) ImportState(ctx context.Context, req tfsdk.ImportResourceStateRequest, resp *tfsdk.ImportResourceStateResponse) {
-	tfsdk.ResourceImportStatePassthroughID(ctx, tftypes.NewAttributePath().WithAttributeName("endpoint_id"), req, resp)
+	// Since an endpoint connection is uniquely identified by two fields, the cluster ID
+	// and the endpoint ID, we serialize them both into the ID field. To make import
+	// work, we need to deserialize an ID back into endpoint ID and cluster ID.
+	matches := privateEndpointConnectionIDRegex.FindStringSubmatch(req.ID)
+	// One match for the full regex, and one for both subgroups
+	if len(matches) != 3 {
+		resp.Diagnostics.AddError(
+			"Invalid private endpoint connection ID format",
+			`When importing a private endpoint connection, the ID field should follow the format "<cluster ID>:<endpoint ID>")`)
+	}
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	connection := PrivateEndpointConnection{
+		ClusterID:  types.String{Value: matches[1]},
+		EndpointID: types.String{Value: matches[2]},
+		ID:         types.String{Value: req.ID},
+	}
+	resp.Diagnostics = resp.State.Set(ctx, &connection)
 }
 
 func waitForEndpointConnectionCreatedFunc(ctx context.Context, clusterID, endpointID string, cl client.Service, connection *client.AwsEndpointConnection) resource.RetryFunc {


### PR DESCRIPTION
Just a quick change to support `import` for connections, even though it probably won't be used often. Follows the same pattern as SQL users. Tested manually, and tested import for services too. I also added a warning comment to the example, since region is configured at the provider level for AWS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/terraform-provider-cockroach/45)
<!-- Reviewable:end -->
