### PR TITLE
Disallow cluster name and provider updates

### DIFF
--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -190,8 +190,9 @@ func (n allowListResource) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	}
 	resp.Diagnostics.AddError(
 		"Couldn't find entry.",
-		fmt.Sprintf("This cluster's allowlist doesn't contain %s/%d", state.CidrIp.Value, state.CidrMask.Value),
+		fmt.Sprintf("This cluster's allowlist doesn't contain %s/%d. Removing from state.", state.CidrIp.Value, state.CidrMask.Value),
 	)
+	resp.State.RemoveResource(ctx)
 }
 
 func (n allowListResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {

--- a/internal/provider/sql_user_resource.go
+++ b/internal/provider/sql_user_resource.go
@@ -155,8 +155,9 @@ func (s sqlUserResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	}
 	resp.Diagnostics.AddError(
 		"Couldn't find user.",
-		fmt.Sprintf("This cluster doesn't have a SQL user named '%v'", state.Name.Value),
+		fmt.Sprintf("This cluster doesn't have a SQL user named '%v'. Removing from state.", state.Name.Value),
 	)
+	resp.State.RemoveResource(ctx)
 }
 
 func (s sqlUserResource) Update(ctx context.Context, req tfsdk.UpdateResourceRequest, resp *tfsdk.UpdateResourceResponse) {


### PR DESCRIPTION
- Name and provider updates no long require replace, but result in a runtime error asking the user to explicitly delete them first if that's what they intended.
- Orthogonal fix: If we can't find a resource on Read, delete it from state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/terraform-provider-cockroach/47)
<!-- Reviewable:end -->
