### PR TITLE
Require spend limit

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -81,11 +81,12 @@ func (r clusterResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Di
 				},
 				Attributes: tfsdk.SingleNestedAttributes(map[string]tfsdk.Attribute{
 					"spend_limit": {
-						Optional: true,
+						Required: true,
 						Type:     types.Int64Type,
 						PlanModifiers: tfsdk.AttributePlanModifiers{
 							tfsdk.UseStateForUnknown(),
 						},
+						MarkdownDescription: "Spend limit in US cents",
 					},
 					"routing_id": {
 						Computed: true,


### PR DESCRIPTION
Users can still pass in a value of zero. It just can't be null, to avoid state errors. We might be able to make it optional again after implementing ModifyResource, but that's a larger change for another day.