### PR TITLE
Fix state updates on read for missing resources

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -318,9 +318,9 @@ func (r clusterResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 	clusterObj, httpResp, err := r.provider.service.GetCluster(ctx, clusterID)
 	if err != nil {
 		if httpResp.StatusCode == http.StatusNotFound {
-			resp.Diagnostics.AddError(
+			resp.Diagnostics.AddWarning(
 				"Cluster not found",
-				fmt.Sprintf("Cluster with clusterID %s is not found. Deleting from state.", clusterID))
+				fmt.Sprintf("Cluster with clusterID %s is not found. Removing from state.", clusterID))
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(

--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -188,10 +188,16 @@ func (n allowListResource) Read(ctx context.Context, req tfsdk.ReadResourceReque
 	for _, entry := range apiResp.GetAllowlist() {
 		if entry.GetCidrIp() == state.CidrIp.Value ||
 			int64(entry.GetCidrMask()) == state.CidrMask.Value {
+			// Update flags in case they've changed externally.
+			state.Sql.Value = entry.GetSql()
+			state.Ui.Value = entry.GetUi()
+			state.Name.Value = entry.GetName()
+			diags = resp.State.Set(ctx, &state)
+			resp.Diagnostics.Append(diags...)
 			return
 		}
 	}
-	resp.Diagnostics.AddError(
+	resp.Diagnostics.AddWarning(
 		"Couldn't find entry.",
 		fmt.Sprintf("This cluster's allowlist doesn't contain %s/%d. Removing from state.", state.CidrIp.Value, state.CidrMask.Value),
 	)

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -200,8 +200,8 @@ func (r privateEndpointConnectionResource) Read(ctx context.Context, req tfsdk.R
 			return
 		}
 	}
-	resp.Diagnostics.AddError("Couldn't find connection",
-		"Endpoint services connection couldn't be located. Removing from state.")
+	resp.Diagnostics.AddWarning("Couldn't find connection",
+		"Endpoint connection couldn't be located. Removing from state.")
 	resp.State.RemoveResource(ctx)
 }
 

--- a/internal/provider/sql_user_resource.go
+++ b/internal/provider/sql_user_resource.go
@@ -159,7 +159,7 @@ func (s sqlUserResource) Read(ctx context.Context, req tfsdk.ReadResourceRequest
 			return
 		}
 	}
-	resp.Diagnostics.AddError(
+	resp.Diagnostics.AddWarning(
 		"Couldn't find user.",
 		fmt.Sprintf("This cluster doesn't have a SQL user named '%v'. Removing from state.", state.Name.Value),
 	)


### PR DESCRIPTION
Apparently, using an error will prevent any state changes. We need to use a warning instead. I also noticed that we're not correctly updating state in Read for allowlist entries and endpoint services, so fixed that.
