### PR TITLE
Fix cluster state on initial creation

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -533,9 +533,8 @@ func loadClusterToTerraformState(clusterObj *client.Cluster, state *CockroachClu
 
 func waitForClusterCreatedFunc(ctx context.Context, id string, cl client.Service, cluster *client.Cluster) resource.RetryFunc {
 	return func() *resource.RetryError {
-		var httpResp *http.Response
-		var err error
-		cluster, httpResp, err = cl.GetCluster(ctx, id)
+		apiCluster, httpResp, err := cl.GetCluster(ctx, id)
+		*cluster = *apiCluster
 		if err != nil {
 			if httpResp.StatusCode < http.StatusInternalServerError {
 				return resource.NonRetryableError(fmt.Errorf("error getting cluster: %s", formatAPIErrorMessage(err)))


### PR DESCRIPTION
Previously, we attempted to copy over cluster state while polling for status, but accidentally overrode the local pointer address instead of the object itself. This change copies the cluster over. Added test cases for cluster and endpoint services, which behaves the same way.