### PR TITLE
Update timeouts and clean up constants

### DIFF
--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -18,18 +18,14 @@ package provider
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const (
-	CockroachAPIKey                  string = "COCKROACH_API_KEY"
-	APIServerURLKey                  string = "COCKROACH_SERVER"
-	UserAgent                        string = "terraform-provider-cockroach"
-	CLUSTERSTATETYPE_CREATED         string = "CREATED"
-	CLUSTERSTATETYPE_CREATION_FAILED string = "CREATION_FAILED"
-	CREATE_TIMEOUT                          = 60 * time.Minute
+	CockroachAPIKey string = "COCKROACH_API_KEY"
+	APIServerURLKey string = "COCKROACH_SERVER"
+	UserAgent       string = "terraform-provider-cockroach"
 )
 
 type Region struct {

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -35,7 +35,7 @@ type privateEndpointConnectionResourceType struct{}
 const (
 	// clusterID:endpointID
 	privateEndpointConnectionIDFmt  = "%s:%s"
-	endpointConnectionCreateTimeout = time.Minute * 5
+	endpointConnectionCreateTimeout = time.Minute * 10
 )
 
 var privateEndpointConnectionIDRegex = regexp.MustCompile(fmt.Sprintf("^(%s):(.*)$", uuidRegex))

--- a/internal/provider/private_endpoint_services_resource.go
+++ b/internal/provider/private_endpoint_services_resource.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -30,6 +31,8 @@ import (
 )
 
 type privateEndpointServicesResourceType struct{}
+
+const endpointServicesCreateTimeout = time.Hour
 
 func (n privateEndpointServicesResourceType) GetSchema(_ context.Context) (tfsdk.Schema, diag.Diagnostics) {
 	return tfsdk.Schema{
@@ -155,7 +158,7 @@ func (n privateEndpointServicesResource) Create(ctx context.Context, req tfsdk.C
 		return
 	}
 	var services client.PrivateEndpointServices
-	err = resource.RetryContext(ctx, CREATE_TIMEOUT,
+	err = resource.RetryContext(ctx, endpointServicesCreateTimeout,
 		waitForEndpointServicesCreatedFunc(ctx, cluster.Id, n.provider.service, &services))
 	if err != nil {
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
Cluster update operations can take a pretty long time, especially multiregion clusters. We had an SE bump into the timeout, even though it was still chugging along. Bumped it to 2 hours. Dropped the endpoint connection timeout to 10 minutes (usually completes in ~30s). Left cluster and endpoint service creation unchanged.

Generally refactored timeout constants, and also a couple unrelated cluster state constants that were hard coded and at risk of going out of sync with the API.

Also opportunistically fixed a fixed a segfault that happened if a call to GetCluster fails in the wait loop, trying to copy the value of a nil cluster pointer.

_Add a description of the problem this PR addresses and an overview of how this PR works_.
