### PR TITLE
Bump default CRDB dedicated version to v22.2

### DIFF
--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -22,7 +22,7 @@ variable "sql_user_password" {
 variable "cockroach_version" {
   type     = string
   nullable = true
-  default  = "v22.1"
+  default  = "v22.2"
 }
 
 variable "cloud_provider" {


### PR DESCRIPTION
Now that v22.2 is GA, bump the default version to v22.2 in the dedicated workflow example.
