### PR TITLE
update manifest protocol version

### DIFF
--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
     "version": 1,
     "metadata": {
-        "protocol_versions": ["5.0"]
+        "protocol_versions": ["6.0"]
     }
 }


### PR DESCRIPTION
This was reported by our friends at Nightfall. Our registry manifest says we use protocol version 5.0 (which is what the TF SDK v2 uses), but we're using the plugin framework, which uses protocol version 6.0.