### PR TITLE
Typo in region name

### DIFF
--- a/examples/resources/cockroach_serverless_cluster/cockroach_serverless_cluster.tf
+++ b/examples/resources/cockroach_serverless_cluster/cockroach_serverless_cluster.tf
@@ -8,7 +8,7 @@ resource "cockroach_cluster" "cockroach" {
   }
   regions = [
     {
-      name = "us-east1"
+      name = "us-east-1"
     }
   ]
 }


### PR DESCRIPTION
us-east1 is not valid, should be us-east-1

_Add a description of the problem this PR addresses and an overview of how this PR works_.
