### PR TITLE
Allowlist resource matches wrong entry on Read

### DIFF
--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -195,7 +195,7 @@ func (r *allowListResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 	for _, entry := range apiResp.GetAllowlist() {
-		if entry.GetCidrIp() == state.CidrIp.ValueString() ||
+		if entry.GetCidrIp() == state.CidrIp.ValueString() &&
 			int64(entry.GetCidrMask()) == state.CidrMask.ValueInt64() {
 			// Update flags in case they've changed externally.
 			state.Sql = types.BoolValue(entry.GetSql())

--- a/internal/provider/networking_resource_test.go
+++ b/internal/provider/networking_resource_test.go
@@ -60,6 +60,14 @@ func TestIntegrationAllowlistEntryResource(t *testing.T) {
 		Sql:      true,
 		Ui:       true,
 	}
+	// Return another entry in the List call to make sure we're selecting
+	// the right one.
+	otherName := "wrong-entry"
+	otherEntry := client.AllowlistEntry{
+		Name:     &otherName,
+		CidrIp:   "192.168.5.4",
+		CidrMask: 32,
+	}
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")
 	}
@@ -94,7 +102,7 @@ func TestIntegrationAllowlistEntryResource(t *testing.T) {
 		Times(3)
 	s.EXPECT().AddAllowlistEntry(gomock.Any(), clusterID, &entry).Return(&entry, nil, nil)
 	s.EXPECT().ListAllowlistEntries(gomock.Any(), clusterID, gomock.Any()).Times(2).Return(
-		&client.ListAllowlistEntriesResponse{Allowlist: []client.AllowlistEntry{entry}}, nil, nil)
+		&client.ListAllowlistEntriesResponse{Allowlist: []client.AllowlistEntry{otherEntry, entry}}, nil, nil)
 	s.EXPECT().DeleteAllowlistEntry(gomock.Any(), clusterID, entry.CidrIp, entry.CidrMask)
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
 


### PR DESCRIPTION
Fixed a logic error where we were checking if the IP address _OR_ the CIDR mask matched instead of the address _AND_mask. Added a regression test.
