### PR TITLE
Make SQL User password optional and generate of omitted

### DIFF
--- a/docs/resources/sql_user.md
+++ b/docs/resources/sql_user.md
@@ -19,7 +19,10 @@ SQL user and password
 
 - `cluster_id` (String)
 - `name` (String)
-- `password` (String, Sensitive)
+
+### Optional
+
+- `password` (String, Sensitive) If provided, this field sets the password of the SQL user when created. If omitted, a random password is generated, but not saved to Terraform state. The password must be changed via the CockroachDB cloud console.
 
 ### Read-Only
 


### PR DESCRIPTION
Previously, password was a required field for SQL users. This caused
import problems because we can't read and set the password (nor do
we want to).

This change makes it optional, and if it's omitted, we randomly
generate a 32-character random password. This password isn't saved
to state, though. The user needs to then change it via the web UI.
Setting the password field to null after the resource is created
will not change the password, but makes Terraform forget it.