### PR TITLE
private_networking_visibility description change - remove PrivateLink as the flag is not required 

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -61,7 +61,7 @@ Optional:
 - `disk_iops` (Number)
 - `machine_type` (String)
 - `num_virtual_cpus` (Number)
-- `private_network_visibility` (Boolean) Set to true to assign private IP addresses to nodes. Required for CMEK, PrivateLink, and other advanced features.
+- `private_network_visibility` (Boolean) Set to true to assign private IP addresses to nodes. Required for CMEK and other advanced networking features.
 - `storage_gib` (Number)
 
 Read-Only:

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -158,7 +158,7 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"private_network_visibility": schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK, PrivateLink, and other advanced features.",
+						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
 						},

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -158,7 +158,7 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"private_network_visibility": schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK and Egress Perimeter Controls.",
+						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK and other advanced networking features.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
 						},

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -158,7 +158,7 @@ func (r *clusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 					"private_network_visibility": schema.BoolAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK.",
+						Description: "Set to true to assign private IP addresses to nodes. Required for CMEK and Egress Perimeter Controls.",
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
 						},


### PR DESCRIPTION
_Add a description of the problem this PR addresses and an overview of how this PR works_.
@alistair-roacher noticed that the docs mentioned PrivateLink requiring private networking when it is not required.