### PR TITLE
Remove deleted clusters from state

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -359,13 +359,21 @@ func (r *clusterResource) Read(
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
 			resp.Diagnostics.AddWarning(
 				"Cluster not found",
-				fmt.Sprintf("Cluster with clusterID %s is not found. Removing from state.", clusterID))
+				fmt.Sprintf("Cluster with ID %s is not found. Removing from state.", clusterID))
 			resp.State.RemoveResource(ctx)
 		} else {
 			resp.Diagnostics.AddError(
 				"Error getting cluster info",
 				fmt.Sprintf("Unexpected error retrieving cluster info: %s", formatAPIErrorMessage(err)))
 		}
+		return
+	}
+
+	if clusterObj.State == client.CLUSTERSTATETYPE_DELETED {
+		resp.Diagnostics.AddWarning(
+			"Cluster has been deleted",
+			fmt.Sprintf("Cluster with ID %s has been externally deleted. Removing from state.", clusterID))
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
Previously, if a cluster was deleted outside of Terraform, whether by a user action or a sweeper, attempting to delete it in Terraform would result in a "cannot delete locked cluster" error. This is only an issue for the cluster resource because GET /cluster doesn't return a 404 like most other endpoints and users can still retrieve details about deleted clusters. We just need to check the status.