### PR TITLE
Remove ExternalId condition from AWS CMEK role policy

### DIFF
--- a/examples/workflows/cockroach_cmek/aws/main.tf
+++ b/examples/workflows/cockroach_cmek/aws/main.tf
@@ -79,8 +79,6 @@ resource "cockroach_cluster" "example" {
   ]
 }
 
-data "cockroach_organization" "example" {}
-
 resource "aws_iam_role" "example" {
   name = "cmek_test_role"
 
@@ -92,11 +90,6 @@ resource "aws_iam_role" "example" {
         "Action" : "sts:AssumeRole",
         "Principal" : {
           "AWS" : cockroach_cluster.example.account_id
-        },
-        "Condition" : {
-          "StringEquals" : {
-            "sts:ExternalId" : data.cockroach_organization.example.id
-          }
         }
       }
     ]


### PR DESCRIPTION
Apparently, this condition is no longer advised and can cause backups to fail. It was removed from the docs shortly after this example was added.