### PR TITLE
[CC-7610] support creating multi-region serverless clusters

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -47,6 +47,7 @@ Required:
 Optional:
 
 - `node_count` (Number)
+- `primary` (Boolean) Selects which region will be the primary. Required only for a Serverless cluster with more than one region.
 
 Read-Only:
 

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -35,58 +35,108 @@ import (
 )
 
 // TestAccClusterResource attempts to create, check, and destroy
-// a real cluster and allowlist entry. It will be skipped if TF_ACC isn't set.
+// a real cluster. It will be skipped if TF_ACC isn't set.
 func TestAccServerlessClusterResource(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2))
 	testServerlessClusterResource(t, clusterName, false)
 }
 
+// TestAccMultiRegionServerlessClusterResource attempts to create, check, and destroy
+// a real multi-region serverless cluster. It will be skipped if TF_ACC isn't set.
+func TestAccMultiRegionServerlessClusterResource(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tftest-multi-region-serverless-%s", GenerateRandomString(2))
+	testMultiRegionServerlessClusterResource(t, clusterName, false)
+}
+
 // TestIntegrationServerlessClusterResource attempts to create, check, and destroy
 // a cluster, but uses a mocked API service.
 func TestIntegrationServerlessClusterResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2))
-	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")
 	}
-
-	ctrl := gomock.NewController(t)
-	s := mock_client.NewMockService(ctrl)
-	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
-		return s
-	})()
-
-	finalCluster := client.Cluster{
-		Id:               clusterID,
-		Name:             clusterName,
-		CockroachVersion: "v22.1.0",
-		Plan:             "SERVERLESS",
-		CloudProvider:    "GCP",
-		State:            "CREATED",
-		Config: client.ClusterConfig{
-			Serverless: &client.ServerlessClusterConfig{
-				SpendLimit: 1,
-				RoutingId:  "routing-id",
+	true_val := true
+	cases := []struct {
+		name         string
+		finalCluster client.Cluster
+		testFunc     func(t *testing.T, clusterName string, useMock bool)
+	}{
+		{
+			"single-region serverless cluster",
+			client.Cluster{
+				Id:               uuid.Nil.String(),
+				Name:             fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2)),
+				CockroachVersion: "v22.1.0",
+				Plan:             "SERVERLESS",
+				CloudProvider:    "GCP",
+				State:            "CREATED",
+				Config: client.ClusterConfig{
+					Serverless: &client.ServerlessClusterConfig{
+						SpendLimit: 1,
+						RoutingId:  "routing-id",
+					},
+				},
+				Regions: []client.Region{
+					{
+						Name: "us-central1",
+					},
+				},
 			},
+			testServerlessClusterResource,
 		},
-		Regions: []client.Region{
-			{
-				Name: "us-central1",
+		{
+			"multi-region serverless cluster",
+			client.Cluster{
+				Id:               uuid.Nil.String(),
+				Name:             fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2)),
+				CockroachVersion: "v22.1.0",
+				Plan:             "SERVERLESS",
+				CloudProvider:    "GCP",
+				State:            "CREATED",
+				Config: client.ClusterConfig{
+					Serverless: &client.ServerlessClusterConfig{
+						SpendLimit: 1,
+						RoutingId:  "routing-id",
+					},
+				},
+				Regions: []client.Region{
+					{
+						Name: "us-west2",
+					},
+					{
+						Name:    "us-east1",
+						Primary: &true_val,
+					},
+					{
+						Name: "europe-west1",
+					},
+				},
 			},
+			testMultiRegionServerlessClusterResource,
 		},
 	}
-	initialCluster := finalCluster
-	initialCluster.State = client.CLUSTERSTATETYPE_CREATING
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			s := mock_client.NewMockService(ctrl)
+			defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+				return s
+			})()
 
-	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
-		Return(&initialCluster, nil, nil)
-	s.EXPECT().GetCluster(gomock.Any(), clusterID).
-		Return(&finalCluster, &http.Response{Status: http.StatusText(http.StatusOK)}, nil).
-		Times(3)
-	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
+			initialCluster := c.finalCluster
+			initialCluster.State = client.CLUSTERSTATETYPE_CREATING
 
-	testServerlessClusterResource(t, clusterName, true)
+			s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+				Return(&initialCluster, nil, nil)
+			s.EXPECT().GetCluster(gomock.Any(), c.finalCluster.Id).
+				Return(&c.finalCluster, &http.Response{Status: http.StatusText(http.StatusOK)}, nil).
+				Times(3)
+			s.EXPECT().DeleteCluster(gomock.Any(), c.finalCluster.Id)
+
+			c.testFunc(t, c.finalCluster.Name, true)
+		})
+	}
 }
 
 func testServerlessClusterResource(t *testing.T, clusterName string, useMock bool) {
@@ -109,6 +159,40 @@ func testServerlessClusterResource(t *testing.T, clusterName string, useMock boo
 					resource.TestCheckResourceAttrSet(resourceName, "cockroach_version"),
 					resource.TestCheckResourceAttr(resourceName, "plan", "SERVERLESS"),
 					resource.TestCheckResourceAttr(resourceName, "state", string(client.CLUSTERSTATETYPE_CREATED)),
+					resource.TestCheckResourceAttr(resourceName, "regions.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testMultiRegionServerlessClusterResource(t *testing.T, clusterName string, useMock bool) {
+	var (
+		resourceName = "cockroach_cluster.serverless"
+		cluster      client.Cluster
+	)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               useMock,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestMultiRegionServerlessClusterResourceConfig(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCockroachClusterExists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", clusterName),
+					resource.TestCheckResourceAttrSet(resourceName, "cloud_provider"),
+					resource.TestCheckResourceAttrSet(resourceName, "cockroach_version"),
+					resource.TestCheckResourceAttr(resourceName, "plan", "SERVERLESS"),
+					resource.TestCheckResourceAttr(resourceName, "state", string(client.CLUSTERSTATETYPE_CREATED)),
+					resource.TestCheckResourceAttr(resourceName, "regions.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "regions.0.name", "us-west2"),
+					resource.TestCheckResourceAttr(resourceName, "regions.0.primary", "false"),
+					resource.TestCheckResourceAttr(resourceName, "regions.1.name", "us-east1"),
+					resource.TestCheckResourceAttr(resourceName, "regions.1.primary", "true"),
+					resource.TestCheckResourceAttr(resourceName, "regions.2.name", "europe-west1"),
+					resource.TestCheckResourceAttr(resourceName, "regions.2.primary", "false"),
 				),
 			},
 		},
@@ -277,6 +361,30 @@ resource "cockroach_cluster" "serverless" {
 	regions = [{
 		name = "us-central1"
 	}]
+}
+`, name)
+}
+
+func getTestMultiRegionServerlessClusterResourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "cockroach_cluster" "serverless" {
+    name           = "%s"
+    cloud_provider = "GCP"
+    serverless = {
+        spend_limit = 1
+    }
+	regions = [
+		{
+			name = "us-west2"
+		},
+		{
+			name = "us-east1"
+			primary = true
+		},
+		{
+			name = "europe-west1"
+		},
+	]
 }
 `, name)
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -33,6 +33,7 @@ type Region struct {
 	SqlDns    types.String `tfsdk:"sql_dns"`
 	UiDns     types.String `tfsdk:"ui_dns"`
 	NodeCount types.Int64  `tfsdk:"node_count"`
+	Primary   types.Bool   `tfsdk:"primary"`
 }
 
 type DedicatedClusterConfig struct {


### PR DESCRIPTION
This change adds a `Primary` field to the region schema, which is required when creating multi-region serverless clusters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/terraform-provider-cockroach/99)
<!-- Reviewable:end -->
