### PR TITLE
Add explicit setup-go for golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,11 @@ jobs:
     name: 'Golint'
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+          
       - name: Checkout sources
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Add explicit setup-go for golangci-lint-action as directed in
https://github.com/golangci/golangci-lint-action#compatibility