### PR TITLE
Revert "update dedicated cluster test (#103)"

### DIFF
--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -229,10 +229,10 @@ func TestIntegrationDedicatedClusterResource(t *testing.T) {
 		UpgradeStatus:    client.CLUSTERUPGRADESTATUSTYPE_UPGRADE_AVAILABLE,
 		Config: client.ClusterConfig{
 			Dedicated: &client.DedicatedHardwareConfig{
-				MachineType:    "n1-standard-4",
-				NumVirtualCpus: 4,
-				StorageGib:     35,
-				MemoryGib:      15,
+				MachineType:    "n1-standard-2",
+				NumVirtualCpus: 2,
+				StorageGib:     15,
+				MemoryGib:      8,
 			},
 		},
 		Regions: []client.Region{
@@ -399,8 +399,8 @@ resource "cockroach_cluster" "dedicated" {
     cloud_provider = "GCP"
     cockroach_version = "%s"
     dedicated = {
-	  storage_gib = 35
-	  machine_type = "n1-standard-4"
+	  storage_gib = 15
+	  machine_type = "n1-standard-2"
     }
 	regions = [{
 		name: "us-central1"


### PR DESCRIPTION
This reverts commit 12a16f9cf7d44a7112ec39fd7396c7f871a59cb2.

Now that the external issue with the lower cost
machine type is fixed, revert to use it again.

