### PR TITLE
Fixed broken links to console access management page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
     cd examples/workflows/cockroach_serverless_cluster
     ~~~
 
-1. The provider requires an API key set in an environment variable named `COCKROACH_API_KEY`. Copy the [API key](https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management#api-access) from the CockroachDB Cloud console and create the `COCKROACH_API_KEY` environment variable.
+1. The provider requires an API key set in an environment variable named `COCKROACH_API_KEY`. Copy the [API key](https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management.html#api-access) from the CockroachDB Cloud console and create the `COCKROACH_API_KEY` environment variable.
 
     ~~~ shell
     export COCKROACH_API_KEY=<YOUR_API_KEY>
@@ -99,7 +99,7 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
     cd examples/workflows/cockroach_dedicated_cluster
     ~~~
 
-1. The provider requires an API key set in an environment variable named `COCKROACH_API_KEY`. Copy the [API key](https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management#api-access) from the CockroachDB Cloud console and create the `COCKROACH_API_KEY` environment variable.
+1. The provider requires an API key set in an environment variable named `COCKROACH_API_KEY`. Copy the [API key](https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management.html#api-access) from the CockroachDB Cloud console and create the `COCKROACH_API_KEY` environment variable.
 
     ~~~ shell
     export COCKROACH_API_KEY=<YOUR_API_KEY>

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ provider "cockroach" {
   # https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api.html
   #
   # Instructions for getting an API Key
-  # https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management#api-access
+  # https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management.html#api-access
   #
   # The Terraform provider requires an environment variable COCKROACH_API_KEY
   # export COCKROACH_API_KEY="the API Key value here"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -3,7 +3,7 @@ provider "cockroach" {
   # https://www.cockroachlabs.com/docs/cockroachcloud/cloud-api.html
   #
   # Instructions for getting an API Key
-  # https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management#api-access
+  # https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management.html#api-access
   #
   # The Terraform provider requires an environment variable COCKROACH_API_KEY
   # export COCKROACH_API_KEY="the API Key value here"


### PR DESCRIPTION
Previously the pages and files below included a broken link to the Console Access Management page:

* https://registry.terraform.io/providers/cockroachdb/cockroach/latest/docs
* [/docs/index.md](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/index.md)
* [/README.md](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/README.md)

The broken link was pointing to 

```
https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management#api-access
```
but by adding `.html` as suffix on the url, the link now works again: 
```
https://www.cockroachlabs.com/docs/cockroachcloud/console-access-management.html#api-access
```