### PR TITLE
Add support for resource limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ default: install
 build:
 	go build -o ${BINARY}
 
+# Generate Terraform Provider docs.
+generate:
+	go generate
+
 update-sdk:
 	go get github.com/cockroachdb/cockroach-cloud-sdk-go
 	go generate ./mock

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -63,5 +63,14 @@ Read-Only:
 
 - `routing_id` (String)
 - `spend_limit` (Number)
+- `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))
+
+<a id="nestedatt--serverless--usage_limits"></a>
+### Nested Schema for `serverless.usage_limits`
+
+Read-Only:
+
+- `request_unit_limit` (Number)
+- `storage_mib_limit` (Number)
 
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -74,12 +74,21 @@ Read-Only:
 <a id="nestedatt--serverless"></a>
 ### Nested Schema for `serverless`
 
-Required:
+Optional:
 
-- `spend_limit` (Number) Spend limit in US cents
+- `spend_limit` (Number) Spend limit in US cents.
+- `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))
 
 Read-Only:
 
 - `routing_id` (String)
+
+<a id="nestedatt--serverless--usage_limits"></a>
+### Nested Schema for `serverless.usage_limits`
+
+Required:
+
+- `request_unit_limit` (Number) Maximum number of request units that the cluster can consume during the month.
+- `storage_mib_limit` (Number) Maximum amount of storage (in MiB) that the cluster can have at any time during the month.
 
 

--- a/examples/workflows/cockroach_cmek/gcp/main.tf
+++ b/examples/workflows/cockroach_cmek/gcp/main.tf
@@ -118,13 +118,13 @@ resource "google_kms_crypto_key_iam_member" "example" {
 # It can take time for policy changes to propagate, so the CMEK resource
 # may fail if created immediately after the policy member.
 resource "time_sleep" "enable_policy_wait" {
-  depends_on = [google_service_account_iam_member.example]
+  depends_on      = [google_service_account_iam_member.example]
   create_duration = "3m"
 }
 
 resource "cockroach_cmek" "example" {
   depends_on = [time_sleep.enable_policy_wait]
-  id = cockroach_cluster.example.id
+  id         = cockroach_cluster.example.id
   regions = /*concat(*/ [
     {
       region : var.gcp_region

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,14 @@ module github.com/cockroachdb/terraform-provider-cockroach
 go 1.18
 
 require (
-	github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.0
+	github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.2
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/terraform-plugin-docs v0.13.0
 	github.com/hashicorp/terraform-plugin-framework v1.1.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.10.0
 	github.com/hashicorp/terraform-plugin-go v0.14.3
+	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/stretchr/testify v1.7.2
 )
@@ -40,7 +41,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.17.3 // indirect
 	github.com/hashicorp/terraform-json v0.14.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.7.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.1.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 // indirect
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,10 +32,8 @@ github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cockroachdb/cockroach-cloud-sdk-go v0.4.4 h1:Dnp77JHIND0ipk04PuY0g2099JiBda0E09Nx4E364rY=
-github.com/cockroachdb/cockroach-cloud-sdk-go v0.4.4/go.mod h1:zVVtMKMcPkwrYgrZ/hv73HiGSsWId3BorWlSpRWc7tM=
-github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.0 h1:SiZRjCzCiZG+gZdTKwiw+P9R2FWP982frbaDM8s+bUc=
-github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.0/go.mod h1:zVVtMKMcPkwrYgrZ/hv73HiGSsWId3BorWlSpRWc7tM=
+github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.2 h1:PTXnEia12WBlQFpGBjRJwDU0iO0oyWMGsiJcvRArJ9I=
+github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.2/go.mod h1:oG9ylbcVGOF7IbVAW2nx5F6ry9a2dZD1H9rd+qd4P60=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/provider/cmek_resource_test.go
+++ b/internal/provider/cmek_resource_test.go
@@ -222,7 +222,6 @@ func testCMEKResource(t *testing.T, clusterName string, useMock bool) {
 	var (
 		clusterResourceName = "cockroach_cluster.test"
 		cmekResourceName    = "cockroach_cmek.test"
-		cluster             client.Cluster
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -233,7 +232,7 @@ func testCMEKResource(t *testing.T, clusterName string, useMock bool) {
 			{
 				Config: getTestCMEKResourceCreateConfig(clusterName),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckCockroachClusterExists(clusterResourceName, &cluster),
+					testCheckCockroachClusterExists(clusterResourceName),
 				),
 			},
 			{

--- a/internal/provider/cockroach_cluster_data_source.go
+++ b/internal/provider/cockroach_cluster_data_source.go
@@ -63,6 +63,17 @@ func (d *clusterDataSource) Schema(
 					"spend_limit": schema.Int64Attribute{
 						Computed: true,
 					},
+					"usage_limits": schema.SingleNestedAttribute{
+						Computed: true,
+						Attributes: map[string]schema.Attribute{
+							"request_unit_limit": schema.Int64Attribute{
+								Computed: true,
+							},
+							"storage_mib_limit": schema.Int64Attribute{
+								Computed: true,
+							},
+						},
+					},
 					"routing_id": schema.StringAttribute{
 						Computed: true,
 					},

--- a/internal/provider/database_resource.go
+++ b/internal/provider/database_resource.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strconv"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -29,7 +28,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 type databaseResource struct {
@@ -300,12 +298,7 @@ func loadDatabaseToTerraformState(
 	// Get the unique ID (required by terraform framework) by combining
 	// the cluster ID and database name.
 	state.ID = types.StringValue(fmt.Sprintf(databaseIDFmt, clusterID, databaseObj.GetName()))
-	tableCountStr := databaseObj.GetTableCount()
-	if tableCountStr != "" {
-		// The API returns an int64 string for table count.
-		tableCountInt, err := strconv.ParseInt(tableCountStr, 10, 64)
-		if err == nil {
-			state.TableCount = basetypes.NewInt64Value(tableCountInt)
-		}
+	if databaseObj.TableCount != nil {
+		state.TableCount = types.Int64Value(*databaseObj.TableCount)
 	}
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -46,8 +46,14 @@ type DedicatedClusterConfig struct {
 }
 
 type ServerlessClusterConfig struct {
-	SpendLimit types.Int64  `tfsdk:"spend_limit"`
-	RoutingId  types.String `tfsdk:"routing_id"`
+	SpendLimit  types.Int64  `tfsdk:"spend_limit"`
+	RoutingId   types.String `tfsdk:"routing_id"`
+	UsageLimits *UsageLimits `tfsdk:"usage_limits"`
+}
+
+type UsageLimits struct {
+	RequestUnitLimit types.Int64 `tfsdk:"request_unit_limit"`
+	StorageMibLimit  types.Int64 `tfsdk:"storage_mib_limit"`
 }
 
 type SQLUser struct {

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client/model_api_database.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client/model_api_database.go
@@ -24,8 +24,8 @@ import (
 
 // ApiDatabase struct for ApiDatabase.
 type ApiDatabase struct {
-	Name       string  `json:"name"`
-	TableCount *string `json:"table_count,omitempty"`
+	Name       string `json:"name"`
+	TableCount *int64 `json:"table_count,omitempty,string"`
 }
 
 // NewApiDatabase instantiates a new ApiDatabase object.
@@ -62,16 +62,16 @@ func (o *ApiDatabase) SetName(v string) {
 }
 
 // GetTableCount returns the TableCount field value if set, zero value otherwise.
-func (o *ApiDatabase) GetTableCount() string {
+func (o *ApiDatabase) GetTableCount() int64 {
 	if o == nil || o.TableCount == nil {
-		var ret string
+		var ret int64
 		return ret
 	}
 	return *o.TableCount
 }
 
-// SetTableCount gets a reference to the given string and assigns it to the TableCount field.
-func (o *ApiDatabase) SetTableCount(v string) {
+// SetTableCount gets a reference to the given int64 and assigns it to the TableCount field.
+func (o *ApiDatabase) SetTableCount(v int64) {
 	o.TableCount = &v
 }
 

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client/model_usage_limits.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client/model_usage_limits.go
@@ -25,16 +25,16 @@ import (
 // UsageLimits struct for UsageLimits.
 type UsageLimits struct {
 	// request_unit_limit is the maximum number of request units that the cluster can consume during the month. If this limit is exceeded, then the cluster is disabled until the limit is increased, or until the beginning of the next month when more free request units are granted. It is an error for this to be zero.
-	RequestUnitLimit string `json:"request_unit_limit"`
-	// storage_mib_limit is the maximum number of Mebibytes of storage that the cluster can have at any time during the month. If this limit is exceeded, then the cluster is throttled; only one SQL connection is allowed at a time, with the expectation that it is used to delete data to reduce storage usage. If is an error for this to be zero.
-	StorageMibLimit string `json:"storage_mib_limit"`
+	RequestUnitLimit int64 `json:"request_unit_limit,string"`
+	// storage_mib_limit is the maximum number of Mebibytes of storage that the cluster can have at any time during the month. If this limit is exceeded, then the cluster is throttled; only one SQL connection is allowed at a time, with the expectation that it is used to delete data to reduce storage usage. It is an error for this to be zero.
+	StorageMibLimit int64 `json:"storage_mib_limit,string"`
 }
 
 // NewUsageLimits instantiates a new UsageLimits object.
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewUsageLimits(requestUnitLimit string, storageMibLimit string) *UsageLimits {
+func NewUsageLimits(requestUnitLimit int64, storageMibLimit int64) *UsageLimits {
 	p := UsageLimits{}
 	p.RequestUnitLimit = requestUnitLimit
 	p.StorageMibLimit = storageMibLimit
@@ -50,9 +50,9 @@ func NewUsageLimitsWithDefaults() *UsageLimits {
 }
 
 // GetRequestUnitLimit returns the RequestUnitLimit field value.
-func (o *UsageLimits) GetRequestUnitLimit() string {
+func (o *UsageLimits) GetRequestUnitLimit() int64 {
 	if o == nil {
-		var ret string
+		var ret int64
 		return ret
 	}
 
@@ -60,14 +60,14 @@ func (o *UsageLimits) GetRequestUnitLimit() string {
 }
 
 // SetRequestUnitLimit sets field value.
-func (o *UsageLimits) SetRequestUnitLimit(v string) {
+func (o *UsageLimits) SetRequestUnitLimit(v int64) {
 	o.RequestUnitLimit = v
 }
 
 // GetStorageMibLimit returns the StorageMibLimit field value.
-func (o *UsageLimits) GetStorageMibLimit() string {
+func (o *UsageLimits) GetStorageMibLimit() int64 {
 	if o == nil {
-		var ret string
+		var ret int64
 		return ret
 	}
 
@@ -75,7 +75,7 @@ func (o *UsageLimits) GetStorageMibLimit() string {
 }
 
 // SetStorageMibLimit sets field value.
-func (o *UsageLimits) SetStorageMibLimit(v string) {
+func (o *UsageLimits) SetStorageMibLimit(v int64) {
 	o.StorageMibLimit = v
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -19,7 +19,7 @@ github.com/armon/go-radix
 # github.com/bgentry/speakeasy v0.1.0
 ## explicit
 github.com/bgentry/speakeasy
-# github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.0
+# github.com/cockroachdb/cockroach-cloud-sdk-go v1.0.2
 ## explicit; go 1.17
 github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
The Cockroach Cloud API now supports a way to limit the number of request units and storage MiB that a cluster can use. This works alongside an existing limit on the $ spend a cluster can incur. A caller can choose to either specify resource limits or a spend limit, but not both. If neither is specified, then the cluster will not have any limits enforced.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/terraform-provider-cockroach/108)
<!-- Reviewable:end -->
