### PR TITLE
Support explicit preview CRDB versions

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -45,6 +45,8 @@ import (
 const (
 	clusterCreateTimeout = time.Hour
 	clusterUpdateTimeout = time.Hour * 2
+
+	clusterVersionPreview = "preview"
 )
 
 type clusterResource struct {
@@ -678,13 +680,16 @@ var versionRE = regexp.MustCompile(
 	// ^major           ^minor           ^patch         ^preRelease       ^metadata
 )
 
-func simplifyClusterVersion(version string) string {
+// simplifyClusterVersion returns the cluster's major version. If planSpecifiesPreviewString
+// is true and the full cluster version has a preview component, returns the magic string
+// "preview".
+func simplifyClusterVersion(version string, planSpecifiesPreviewString bool) string {
 	parts := versionRE.FindStringSubmatch(version)
 	if parts == nil {
 		return version
 	}
-	if parts[4] != "" {
-		return "preview"
+	if planSpecifiesPreviewString && parts[4] != "" {
+		return clusterVersionPreview
 	}
 	return fmt.Sprintf("v%s.%s", parts[1], parts[2])
 }
@@ -712,7 +717,8 @@ func loadClusterToTerraformState(
 	state.ID = types.StringValue(clusterObj.Id)
 	state.Name = types.StringValue(clusterObj.Name)
 	state.CloudProvider = types.StringValue(string(clusterObj.CloudProvider))
-	state.CockroachVersion = types.StringValue(simplifyClusterVersion(clusterObj.CockroachVersion))
+	planSpecifiesPreviewString := plan != nil && plan.CockroachVersion.ValueString() == clusterVersionPreview
+	state.CockroachVersion = types.StringValue(simplifyClusterVersion(clusterObj.CockroachVersion, planSpecifiesPreviewString))
 	state.Plan = types.StringValue(string(clusterObj.Plan))
 	if clusterObj.AccountId == nil {
 		state.AccountId = types.StringNull()

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -467,3 +467,18 @@ func TestSortRegionsByPlan(t *testing.T) {
 		sortRegionsByPlan(&regions, plan)
 	})
 }
+
+func TestSimplifyClusterVersion(t *testing.T) {
+	t.Run("Normal version", func(t *testing.T) {
+		require.Equal(t, "v22.2", simplifyClusterVersion("v22.2.10", false))
+	})
+	t.Run("Normal version, plan uses preview", func(t *testing.T) {
+		require.Equal(t, "v22.2", simplifyClusterVersion("v22.2.10", true))
+	})
+	t.Run("Preview version", func(t *testing.T) {
+		require.Equal(t, "v23.1", simplifyClusterVersion("v23.1.0-beta1", false))
+	})
+	t.Run("Preview version, plan uses preview", func(t *testing.T) {
+		require.Equal(t, "preview", simplifyClusterVersion("v23.1.0-beta1", true))
+	})
+}


### PR DESCRIPTION
Previously, we only allowed the magic string "preview" to create new clusters with a preview crdb build. Now, the API supports cluster creation with the major version of the requested preview. That means the Terraform cluster won't get into a bad state once the version moves out of preview. This change attempts to match the version format of the state to the version format of the config when using preview versions.
