### PR TITLE
Send public network visibility when not private

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -341,6 +341,9 @@ func (r *clusterResource) Create(
 			if cfg.PrivateNetworkVisibility.ValueBool() {
 				visibilityPrivate := client.NETWORKVISIBILITYTYPE_PRIVATE
 				dedicated.NetworkVisibility = &visibilityPrivate
+			} else {
+				visibilityPublic := client.NETWORKVISIBILITYTYPE_PUBLIC
+				dedicated.NetworkVisibility = &visibilityPublic
 			}
 		}
 		clusterSpec.SetDedicated(dedicated)


### PR DESCRIPTION
Previously on cluster creation, if the network_visibility was not explicitly set to private than, the unspecified or nil value was sent. This was problematic because Azure clusters require network_visibility of public to be passed.

Release Note: During cluster creation, explicitly send network_visibility of public if network_visibility of false is not set.

I'm not actually sure if this is what we want here.  It doesn't appear that the CC API documents the default value of network_visibility.

<img width="641" alt="Screenshot 2023-05-10 at 11 04 44 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/6658984/010a4d00-9247-4016-8dbd-324f6d37ce10">

One other option that could work instead of this change is to send the exact network visibility that is specified.  For example, if it was set to private, we'd send private, if it was set to public we'd send public and if it wasn't specified we'd send not_specified. 

Now that I'm thinking through this there is another option which is to coerce an unspecified value for azure to be network_visibility public inside the CCAPI.
