### PR TITLE
Improve README variable description formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- improved formatting of variable descriptions in README
+
 ## [0.5.0] - 2023-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
     sql_user_password = "<SQL user password>"
     ~~~
 
-    Where:
-        - `<cluster name>` is the name of the cluster you want to create.
-        - `<SQL user name>` is the name of the SQL user you want to create.
-        - `<SQL user password>` is the password for the SQL user you want to create.
+    Where:  
+        - `<cluster name>` is the name of the cluster you want to create.  
+        - `<SQL user name>` is the name of the SQL user you want to create.  
+        - `<SQL user password>` is the password for the SQL user you want to create.  
 
 1. Initialize the provider.
 
@@ -125,20 +125,20 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
     os = "<OS name>"
     ~~~
 
-    Where:
-        - `<cluster name>` is the name of the cluster you want to create.
-        - `<database name>` is the name that will be used for the database created within the cluster. This database is in addition to defaultdb which is created by default.
-        - `<SQL user name>` is the name of the SQL user you want to create.
-        - `<SQL user password>` is the password for the SQL user you want to create.
-        - `<cloud provider>` is the cloud infrastructure provider. Possible values are `GCP` or `AWS` or `AZURE` (limited access).
-        - `<cloud provider region>` is the region code or codes for the cloud infrastructure provider. For multi-region clusters, separate each region with a comma.
-        - `<number of nodes>` is the number of nodes in each region. Cockroach Labs recommends at least 3 nodes per region, and the same number of nodes in each region for multi-region clusters.
-        - `<storage in GiB>` is the amount of storage specified in GiB.
-        - `<cloud provider machine type>` is the machine type for the cloud infrastructure provider.
-        - `<allow list name>` is the name for the IP allow list. Use a descriptive name to identify the IP allow list.
-        - `<allow list CIDR IP>` is the Classless Inter-Domain Routing (CIDR) IP address base.
-        - `<allow list CIDR prefix>` is the CIDR prefix. This should be a number from 0 to 32. Use 32 to only allow the single IP Address passed in cidr_ip.
-        - `<OS name>` is the name of the OS that will be used to connect from for connection string output. Possible values are ('WINDOWS', 'MAC', and 'LINUX').
+    Where:  
+        - `<cluster name>` is the name of the cluster you want to create.  
+        - `<database name>` is the name that will be used for the database created within the cluster. This database is in addition to defaultdb which is created by default.  
+        - `<SQL user name>` is the name of the SQL user you want to create.  
+        - `<SQL user password>` is the password for the SQL user you want to create.  
+        - `<cloud provider>` is the cloud infrastructure provider. Possible values are `GCP` or `AWS` or `AZURE` (limited access).  
+        - `<cloud provider region>` is the region code or codes for the cloud infrastructure provider. For multi-region clusters, separate each region with a comma.  
+        - `<number of nodes>` is the number of nodes in each region. Cockroach Labs recommends at least 3 nodes per region, and the same number of nodes in each region for multi-region clusters.  
+        - `<storage in GiB>` is the amount of storage specified in GiB.  
+        - `<cloud provider machine type>` is the machine type for the cloud infrastructure provider.  
+        - `<allow list name>` is the name for the IP allow list. Use a descriptive name to identify the IP allow list.  
+        - `<allow list CIDR IP>` is the Classless Inter-Domain Routing (CIDR) IP address base.  
+        - `<allow list CIDR prefix>` is the CIDR prefix. This should be a number from 0 to 32. Use 32 to only allow the single IP Address passed in cidr_ip.  
+        - `<OS name>` is the name of the OS that will be used to connect from for connection string output. Possible values are ('WINDOWS', 'MAC', and 'LINUX').  
 
 1. Initialize the provider.
 


### PR DESCRIPTION
It looks like some formatting was lost on the list of variable descriptions for the examples in the README.  I've added trailing double spaces after these lines to linebreak them.

Previously:

<img width="1105" alt="Screenshot 2023-05-12 at 11 41 55 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/6658984/d9156fb0-1d1a-4907-b888-fb4329e9a15d">

After this PR:

<img width="1266" alt="Screenshot 2023-05-12 at 11 41 35 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/6658984/16566bf3-22e0-4f4a-b5ad-e907bf853737">
