### PR TITLE
Do not allow dedicated regions to be marked primary

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -47,7 +47,7 @@ Required:
 Optional:
 
 - `node_count` (Number)
-- `primary` (Boolean)
+- `primary` (Boolean) Set to true to mark this region as the primary for a Serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.
 
 Read-Only:
 

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -65,7 +65,7 @@ Required:
 Optional:
 
 - `node_count` (Number)
-- `primary` (Boolean)
+- `primary` (Boolean) Set to true to mark this region as the primary for a Serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.
 
 Read-Only:
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -72,8 +72,9 @@ var regionSchema = schema.NestedAttributeObject{
 			},
 		},
 		"primary": schema.BoolAttribute{
-			Optional: true,
-			Computed: true,
+			Optional:    true,
+			Computed:    true,
+			Description: "Set to true to mark this region as the primary for a Serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.",
 			PlanModifiers: []planmodifier.Bool{
 				boolplanmodifier.UseStateForUnknown(),
 			},
@@ -252,6 +253,10 @@ func (r *clusterResource) ConfigValidators(_ context.Context) []resource.ConfigV
 		resourcevalidator.Conflicting(
 			path.MatchRoot("serverless").AtName("spend_limit"),
 			path.MatchRoot("serverless").AtName("usage_limits"),
+		),
+		resourcevalidator.Conflicting(
+			path.MatchRoot("regions").AtAnyListIndex().AtName("primary"),
+			path.MatchRoot("dedicated"),
 		),
 	}
 }


### PR DESCRIPTION
If a dedicated cluster has a primary region, the plan that's created doesn't match the state of the cluster. This change creates an error if a dedicated cluster's region is marked as primary, and adds some documentation to specify that only serverless regions should me marked primary.

Fixes #113