### PR TITLE
Add cluster checks to log and metric export resources

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -857,13 +857,18 @@ func waitForClusterReadyFunc(
 		if cluster.State == client.CLUSTERSTATETYPE_CREATION_FAILED {
 			return sdk_resource.NonRetryableError(fmt.Errorf("cluster creation failed"))
 		}
+		if cluster.State == client.CLUSTERSTATETYPE_DELETED {
+			return sdk_resource.NonRetryableError(fmt.Errorf("cluster was deleted"))
+		}
 		return sdk_resource.RetryableError(fmt.Errorf("cluster is not ready yet"))
 	}
 }
 
 // waitForClusterLock checks to see if the cluster is locked by any sort of automatic job,
 // and waits if necessary before proceeding.
-func waitForClusterLock(ctx context.Context, state CockroachCluster, s client.Service, diags *diag.Diagnostics) {
+func waitForClusterLock(
+	ctx context.Context, state CockroachCluster, s client.Service, diags *diag.Diagnostics,
+) {
 	if state.State.ValueString() == string(client.CLUSTERSTATETYPE_LOCKED) {
 		tflog.Info(ctx, "Cluster is locked. Waiting for the operation to finish.")
 		clusterObj, _, err := s.GetCluster(ctx, state.ID.ValueString())

--- a/internal/provider/metric_export_datadog_config_resource.go
+++ b/internal/provider/metric_export_datadog_config_resource.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -104,8 +106,9 @@ func (r *metricExportDatadogConfigResource) Create(
 		return
 	}
 
+	clusterID := plan.ID.ValueString()
 	// Check cluster
-	cluster, _, err := r.provider.service.GetCluster(ctx, plan.ID.ValueString())
+	cluster, _, err := r.provider.service.GetCluster(ctx, clusterID)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error getting cluster",
@@ -131,21 +134,21 @@ func (r *metricExportDatadogConfigResource) Create(
 		return
 	}
 
-	apiObj, _, err := r.provider.service.EnableDatadogMetricExport(
-		ctx,
-		plan.ID.ValueString(),
+	apiObj := &client.DatadogMetricExportInfo{}
+	err = sdk_resource.RetryContext(ctx, clusterUpdateTimeout, retryEnableDatadogMetricExport(
+		ctx, clusterUpdateTimeout, r.provider.service, clusterID, cluster,
 		client.NewEnableDatadogMetricExportRequest(plan.ApiKey.ValueString(), *site),
-	)
+		apiObj,
+	))
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error enabling Datadog metric export",
-			fmt.Sprintf("Could not enable Datadog metric export: %v", formatAPIErrorMessage(err)),
+			"Error enabling Datadog metric export", err.Error(),
 		)
 		return
 	}
 
 	err = sdk_resource.RetryContext(ctx, clusterUpdateTimeout,
-		waitForDatdogMetricExportReadyFunc(ctx, plan.ID.ValueString(), r.provider.service, apiObj))
+		waitForDatdogMetricExportReadyFunc(ctx, clusterID, r.provider.service, apiObj))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error enabling Datadog metric export",
@@ -160,6 +163,40 @@ func (r *metricExportDatadogConfigResource) Create(
 	loadDatadogMetricExportIntoTerraformState(apiObj, &state)
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
+}
+
+func retryEnableDatadogMetricExport(
+	ctx context.Context,
+	timeout time.Duration,
+	cl client.Service,
+	clusterID string,
+	cluster *client.Cluster,
+	apiRequest *client.EnableDatadogMetricExportRequest,
+	apiObj *client.DatadogMetricExportInfo,
+) sdk_resource.RetryFunc {
+	return func() *sdk_resource.RetryError {
+		apiResp, httpResp, err := cl.EnableDatadogMetricExport(ctx, clusterID, apiRequest)
+		if err != nil {
+			apiErrMsg := formatAPIErrorMessage(err)
+			if (httpResp != nil && httpResp.StatusCode == http.StatusServiceUnavailable) ||
+				strings.Contains(apiErrMsg, "lock") {
+				// Wait for cluster to be ready.
+				clusterErr := sdk_resource.RetryContext(ctx, clusterUpdateTimeout,
+					waitForClusterReadyFunc(ctx, clusterID, cl, cluster))
+				if clusterErr != nil {
+					return sdk_resource.NonRetryableError(
+						fmt.Errorf("error checking cluster availability: %s", clusterErr.Error()))
+				}
+				return sdk_resource.RetryableError(fmt.Errorf("cluster was not ready - trying again"))
+			}
+
+			return sdk_resource.NonRetryableError(
+				fmt.Errorf("could not enable Datadog metric export: %v", apiErrMsg),
+			)
+		}
+		*apiObj = *apiResp
+		return nil
+	}
 }
 
 func loadDatadogMetricExportIntoTerraformState(
@@ -220,6 +257,7 @@ func (r *metricExportDatadogConfigResource) Read(
 	if resp.Diagnostics.HasError() || state.ID.IsNull() {
 		return
 	}
+
 	clusterID := state.ID.ValueString()
 	apiObj, httpResp, err := r.provider.service.GetDatadogMetricExportInfo(ctx, clusterID)
 	if err != nil {
@@ -227,11 +265,42 @@ func (r *metricExportDatadogConfigResource) Read(
 			resp.Diagnostics.AddWarning(
 				"Datadog metric export config not found",
 				fmt.Sprintf(
-					"the Datadog metric export config with cluster ID %s is not found. Removing from state.",
+					"The Datadog metric export config with cluster ID %s is not found. Removing from state.",
 					clusterID,
 				))
 			resp.State.RemoveResource(ctx)
+			return
 		} else {
+			// Check cluster existence.
+			cluster, clusterHttpResp, clusterErr := r.provider.service.GetCluster(ctx, clusterID)
+			if clusterErr != nil {
+				if clusterHttpResp != nil && clusterHttpResp.StatusCode == http.StatusNotFound {
+					resp.Diagnostics.AddWarning(
+						"Cluster not found",
+						fmt.Sprintf("The Datadog metric export config's cluster with ID %s is not found. Removing from state.",
+							clusterID,
+						))
+					resp.State.RemoveResource(ctx)
+					return
+				} else {
+					resp.Diagnostics.AddError(
+						"Error getting cluster",
+						fmt.Sprintf("Unexpected error retrieving the Datadog metric export config's cluster: %s",
+							formatAPIErrorMessage(clusterErr),
+						))
+				}
+			}
+
+			if cluster.State == client.CLUSTERSTATETYPE_DELETED {
+				resp.Diagnostics.AddWarning(
+					"Cluster deleted",
+					fmt.Sprintf("The Datadog metric export config's cluster with ID %s was deleted. Removing from state.",
+						clusterID,
+					))
+				resp.State.RemoveResource(ctx)
+				return
+			}
+
 			resp.Diagnostics.AddError(
 				"Error getting Datadog metric export info",
 				fmt.Sprintf("Unexpected error retrieving Datadog metric export info: %s", formatAPIErrorMessage(err)))
@@ -273,21 +342,23 @@ func (r *metricExportDatadogConfigResource) Update(
 		return
 	}
 
-	apiObj, _, err := r.provider.service.EnableDatadogMetricExport(
-		ctx,
-		plan.ID.ValueString(),
+	clusterID := plan.ID.ValueString()
+	cluster := &client.Cluster{}
+	apiObj := &client.DatadogMetricExportInfo{}
+	err = sdk_resource.RetryContext(ctx, clusterUpdateTimeout, retryEnableDatadogMetricExport(
+		ctx, clusterUpdateTimeout, r.provider.service, clusterID, cluster,
 		client.NewEnableDatadogMetricExportRequest(plan.ApiKey.ValueString(), *site),
-	)
+		apiObj,
+	))
 	if err != nil {
 		resp.Diagnostics.AddError(
-			"Error enabling Datadog metric export",
-			fmt.Sprintf("Could not enable Datadog metric export: %v", formatAPIErrorMessage(err)),
+			"Error enabling Datadog metric export", err.Error(),
 		)
 		return
 	}
 
 	err = sdk_resource.RetryContext(ctx, clusterUpdateTimeout,
-		waitForDatdogMetricExportReadyFunc(ctx, plan.ID.ValueString(), r.provider.service, apiObj))
+		waitForDatdogMetricExportReadyFunc(ctx, clusterID, r.provider.service, apiObj))
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error enabling Datadog metric export",
@@ -315,17 +386,43 @@ func (r *metricExportDatadogConfigResource) Delete(
 	}
 
 	clusterID := state.ID.ValueString()
-	_, httpResp, err := r.provider.service.DeleteDatadogMetricExport(ctx, clusterID)
-	if err != nil {
-		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
-			// Datadog metric export config or cluster is already gone. Swallow the error.
-		} else {
-			resp.Diagnostics.AddError(
-				"Error deleting Datadog metric export config",
-				fmt.Sprintf("Could not delete Datadog metric export config: %s", formatAPIErrorMessage(err)),
-			)
-			return
+	cluster := &client.Cluster{}
+	retry := func() sdk_resource.RetryFunc {
+		return func() *sdk_resource.RetryError {
+			_, httpResp, err := r.provider.service.DeleteDatadogMetricExport(ctx, clusterID)
+			if err != nil {
+				apiErrMsg := formatAPIErrorMessage(err)
+				if httpResp != nil {
+					if httpResp.StatusCode == http.StatusNotFound {
+						// Datadog metric export config or cluster is already gone. Swallow the error.
+						return nil
+					}
+
+					if httpResp.StatusCode == http.StatusServiceUnavailable ||
+						strings.Contains(apiErrMsg, "lock") {
+						// Wait for cluster to be ready.
+						clusterErr := sdk_resource.RetryContext(ctx, clusterUpdateTimeout,
+							waitForClusterReadyFunc(ctx, clusterID, r.provider.service, cluster))
+						if clusterErr != nil {
+							return sdk_resource.NonRetryableError(
+								fmt.Errorf("Error checking cluster availability: %s", clusterErr.Error()))
+						}
+						return sdk_resource.RetryableError(fmt.Errorf("cluster was not ready - trying again"))
+					}
+				}
+				return sdk_resource.NonRetryableError(
+					fmt.Errorf("could not delete Datadog metric export config: %v", apiErrMsg))
+			}
+			return nil
 		}
+	}
+
+	err := sdk_resource.RetryContext(ctx, clusterUpdateTimeout, retry())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error deleting Datadog metric export config", err.Error(),
+		)
+		return
 	}
 
 	// Remove resource from state


### PR DESCRIPTION
Fix for https://github.com/cockroachdb/terraform-provider-cockroach/issues/117
Previously, log and metric export changes competed 
for the cluster lock and failed if it was not
available. Now, they wait for the cluster lock's
release before retrying. Read for these resources 
also now handles deleted clusters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/terraform-provider-cockroach/127)
<!-- Reviewable:end -->
