### PR TITLE
internal/provider: fixes a panic when trying to import a serverless cluster

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,7 +11,7 @@
 1. Navigate to the `terraform-provider-cockroach` directory.
 
     ~~~ shell
-    cd terraform-proivder-cockroach
+    cd terraform-provider-cockroach
     ~~~
 
 1. Build the binary and copy it to your path.

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -785,15 +785,15 @@ func loadClusterToTerraformState(
 			RoutingId: types.StringValue(clusterObj.Config.Serverless.RoutingId),
 		}
 
-		// Set either the spend limit or usage limits, depending on which the plan
-		// requested. Both options are returned by the API.
-		if plan.ServerlessConfig.UsageLimits != nil {
+		// Set either the spend limit or usage limits, depending on the cluster
+		// object requested. Both options are returned by the API.
+		if clusterObj.Config.Serverless.UsageLimits != nil {
 			usageLimits := clusterObj.Config.Serverless.UsageLimits
 			serverlessConfig.UsageLimits = &UsageLimits{
 				RequestUnitLimit: types.Int64Value(usageLimits.RequestUnitLimit),
 				StorageMibLimit:  types.Int64Value(usageLimits.StorageMibLimit),
 			}
-		} else if !plan.ServerlessConfig.SpendLimit.IsNull() {
+		} else if clusterObj.Config.Serverless.SpendLimit != nil {
 			serverlessConfig.SpendLimit = types.Int64Value(int64(clusterObj.Config.Serverless.GetSpendLimit()))
 		}
 		state.ServerlessConfig = serverlessConfig

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -222,8 +222,17 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			})()
 
 			steps := []resource.TestStep{
+				// Create initial resource.
 				serverlessClusterWithSpendLimit(initialCluster.Name),
-				c.testStep(initialCluster.Name)}
+				// Apply an update.
+				c.testStep(initialCluster.Name),
+				// Import the resource.
+				{
+					ResourceName:      "cockroach_cluster.serverless",
+					ImportState:       true,
+					ImportStateVerify: true,
+				},
+			}
 
 			s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
 				Return(&initialCluster, nil, nil)
@@ -234,7 +243,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 				Times(4)
 			s.EXPECT().GetCluster(gomock.Any(), c.finalCluster.Id).
 				Return(&c.finalCluster, &http.Response{Status: http.StatusText(http.StatusOK)}, nil).
-				Times(2)
+				Times(3)
 			s.EXPECT().DeleteCluster(gomock.Any(), c.finalCluster.Id)
 
 			resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Fixes https://github.com/cockroachdb/terraform-provider-cockroach/issues/131. Regression from https://github.com/cockroachdb/terraform-provider-cockroach/pull/108.

This commit fixes a panic when trying to import a serverless cluster through
terraform. We were originally reading from `clusterObj.Config.Serverless`, but
after https://github.com/cockroachdb/terraform-provider-cockroach/pull/108, we end up checking on `plan.ServerlessConfig`, which is incorrect.