### PR TITLE
internal/provider: add network allowlist support for serverless clusters

### DIFF
--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -130,23 +130,6 @@ func (r *allowListResource) Create(
 		return
 	}
 
-	cluster, _, err := r.provider.service.GetCluster(ctx, entry.ClusterId.ValueString())
-	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error getting the cluster",
-			fmt.Sprintf("Could not get the cluster: %s", formatAPIErrorMessage(err)),
-		)
-		return
-	}
-
-	if cluster.Config.Serverless != nil {
-		resp.Diagnostics.AddError(
-			"Could not add network allowlist in serverless cluster",
-			"Network allowlists are only supported with dedicated clusters",
-		)
-		return
-	}
-
 	var allowList = client.AllowlistEntry{
 		CidrIp:   entry.CidrIp.ValueString(),
 		CidrMask: int32(entry.CidrMask.ValueInt64()),
@@ -159,7 +142,7 @@ func (r *allowListResource) Create(
 		allowList.Name = &name
 	}
 
-	_, _, err = r.provider.service.AddAllowlistEntry(ctx, entry.ClusterId.ValueString(), &allowList)
+	_, _, err := r.provider.service.AddAllowlistEntry(ctx, entry.ClusterId.ValueString(), &allowList)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error adding allowed IP range",


### PR DESCRIPTION
Previously, we disallowed network allowlist usage for serverless clusters. Now
that CockroachCloud supports this feature for all serverless clusters, we will
remove that guard, and this commit does that.