### PR TITLE
intrusion/provider: add private endpoints support for serverless clusters

### DIFF
--- a/internal/provider/networking_resource_test.go
+++ b/internal/provider/networking_resource_test.go
@@ -233,11 +233,11 @@ func testAllowlistEntryResource(
 	var uiVal string
 	if isServerless {
 		clusterResourceName = serverlessClusterResourceName
-		allowlistEntryResourceConfigFn = allowlistEntryResourceConfigForServerless
+		allowlistEntryResourceConfigFn = getTestAllowlistEntryResourceConfigForServerless
 		uiVal = "false"
 	} else {
 		clusterResourceName = dedicatedClusterResourceName
-		allowlistEntryResourceConfigFn = allowlistEntryResourceConfigForDedicated
+		allowlistEntryResourceConfigFn = getTestAllowlistEntryResourceConfigForDedicated
 		uiVal = "true"
 	}
 	resource.Test(t, resource.TestCase{
@@ -306,7 +306,7 @@ func testAllowlistEntryExists(resourceName, clusterResourceName string) resource
 	}
 }
 
-func allowlistEntryResourceConfigForDedicated(
+func getTestAllowlistEntryResourceConfigForDedicated(
 	clusterName string, entry *client.AllowlistEntry,
 ) string {
 	return fmt.Sprintf(`
@@ -333,7 +333,7 @@ resource "cockroach_allow_list" "network_list" {
 `, clusterName, *entry.Name, entry.CidrIp, entry.CidrMask, entry.Sql, entry.Ui)
 }
 
-func allowlistEntryResourceConfigForServerless(
+func getTestAllowlistEntryResourceConfigForServerless(
 	clusterName string, entry *client.AllowlistEntry,
 ) string {
 	return fmt.Sprintf(`

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -134,13 +134,7 @@ func (r *privateEndpointConnectionResource) Create(
 		return
 	}
 
-	if cluster.Config.Serverless != nil {
-		resp.Diagnostics.AddError(
-			"Incompatible cluster type",
-			"Private endpoint services are only available for dedicated clusters",
-		)
-		return
-	} else if cluster.CloudProvider != client.CLOUDPROVIDERTYPE_AWS {
+	if cluster.CloudProvider != client.CLOUDPROVIDERTYPE_AWS {
 		resp.Diagnostics.AddError(
 			"Incompatible cluster cloud provider",
 			"Private endpoint services are only available for AWS clusters",


### PR DESCRIPTION
Previously, we disallowed private endpoints support for serverless
clusters. Now that CockroachCloud supports this feature for all serverless
clusters, we will remove that guard, and this commit does that.