### PR TITLE
Test fixes

### DIFF
--- a/internal/provider/client_ca_cert_resource_test.go
+++ b/internal/provider/client_ca_cert_resource_test.go
@@ -67,8 +67,9 @@ func TestIntegrationClientCACertResource(t *testing.T) {
 		State:         "CREATED",
 		Config: client.ClusterConfig{
 			Dedicated: &client.DedicatedHardwareConfig{
-				MachineType: "m5.xlarge",
-				StorageGib:  35,
+				MachineType:    "m5.xlarge",
+				NumVirtualCpus: 4,
+				StorageGib:     35,
 			},
 		},
 		Regions: []client.Region{
@@ -186,7 +187,7 @@ resource "cockroach_cluster" "test" {
 	cloud_provider = "AWS"
 	dedicated = {
 		storage_gib = 35
-		machine_type = "m5.xlarge"
+		num_virtual_cpus = 4
 	}
 	regions = [{
 		name = "us-west-2"

--- a/internal/provider/cmek_resource_test.go
+++ b/internal/provider/cmek_resource_test.go
@@ -256,7 +256,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-central-1"
@@ -285,7 +285,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-central-1"

--- a/internal/provider/log_export_config_resource_test.go
+++ b/internal/provider/log_export_config_resource_test.go
@@ -236,7 +236,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
@@ -270,7 +270,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"

--- a/internal/provider/maintenance_window_test.go
+++ b/internal/provider/maintenance_window_test.go
@@ -150,7 +150,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib  = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
@@ -173,7 +173,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib  = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"

--- a/internal/provider/metric_export_cloudwatch_config_resource_test.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource_test.go
@@ -212,7 +212,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
@@ -235,7 +235,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"

--- a/internal/provider/metric_export_datadog_config_resource_test.go
+++ b/internal/provider/metric_export_datadog_config_resource_test.go
@@ -210,7 +210,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
@@ -233,7 +233,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"

--- a/internal/provider/networking_resource_test.go
+++ b/internal/provider/networking_resource_test.go
@@ -129,8 +129,9 @@ func TestIntegrationAllowlistEntryResource(t *testing.T) {
 				CloudProvider: "AWS",
 				Config: client.ClusterConfig{
 					Dedicated: &client.DedicatedHardwareConfig{
-						StorageGib:  15,
-						MachineType: "m5.large",
+						StorageGib:     15,
+						MachineType:    "m5.large",
+						NumVirtualCpus: 2,
 					},
 				},
 				State: "CREATED",
@@ -315,7 +316,7 @@ resource "cockroach_cluster" "dedicated" {
     cloud_provider = "AWS"
     dedicated = {
         storage_gib = 15
-        machine_type = "m5.large"
+        num_virtual_cpus = 2
     }
     regions = [{
         name: "ap-south-1"

--- a/internal/provider/private_endpoint_connection_resource_test.go
+++ b/internal/provider/private_endpoint_connection_resource_test.go
@@ -91,8 +91,8 @@ func TestIntegrationPrivateEndpointConnectionResource(t *testing.T) {
 				CloudProvider: "AWS",
 				Config: client.ClusterConfig{
 					Dedicated: &client.DedicatedHardwareConfig{
-						StorageGib:  15,
-						MachineType: "m5.large",
+						StorageGib:     15,
+						NumVirtualCpus: 2,
 					},
 				},
 				State: "CREATED",
@@ -217,7 +217,7 @@ resource "cockroach_cluster" "dedicated" {
     cloud_provider = "AWS"
     dedicated = {
         storage_gib = 15
-        machine_type = "m5.large"
+        num_virtual_cpus = 2
     }
     regions = [{
         name: "us-east-1"

--- a/internal/provider/private_endpoint_services_resource_test.go
+++ b/internal/provider/private_endpoint_services_resource_test.go
@@ -92,8 +92,9 @@ func TestIntegrationPrivateEndpointServicesResource(t *testing.T) {
 				CloudProvider: "AWS",
 				Config: client.ClusterConfig{
 					Dedicated: &client.DedicatedHardwareConfig{
-						StorageGib:  15,
-						MachineType: "m5.large",
+						StorageGib:     15,
+						MachineType:    "m5.large",
+						NumVirtualCpus: 2,
 					},
 				},
 				State: "CREATED",
@@ -201,7 +202,7 @@ resource "cockroach_cluster" "dedicated" {
     cloud_provider = "AWS"
     dedicated = {
 	  storage_gib = 15
-	  machine_type = "m5.large"
+	  num_virtual_cpus = 2
     }
 	regions = [{
 		name: "ap-south-1"

--- a/internal/provider/version_deferral_test.go
+++ b/internal/provider/version_deferral_test.go
@@ -146,7 +146,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib  = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
@@ -167,7 +167,7 @@ resource "cockroach_cluster" "test" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib  = 35
-  	machine_type = "m5.xlarge"
+  	num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"


### PR DESCRIPTION
- Updated cluster state import logic to check the plan for which limit type to set
- Updated tests that use machine_type to use num_virtual_cpus instead, for futureproofing

Running tests manually now. Will make sure they're passing before merging.