### PR TITLE
internal/provider: expose the internal_dns field within the region model

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -49,6 +49,7 @@ Read-Only:
 
 Read-Only:
 
+- `internal_dns` (String)
 - `name` (String)
 - `node_count` (Number)
 - `primary` (Boolean)

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -51,6 +51,7 @@ Optional:
 
 Read-Only:
 
+- `internal_dns` (String)
 - `sql_dns` (String)
 - `ui_dns` (String)
 

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -69,6 +69,7 @@ Optional:
 
 Read-Only:
 
+- `internal_dns` (String)
 - `sql_dns` (String)
 - `ui_dns` (String)
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -64,6 +64,9 @@ var regionSchema = schema.NestedAttributeObject{
 		"ui_dns": schema.StringAttribute{
 			Computed: true,
 		},
+		"internal_dns": schema.StringAttribute{
+			Computed: true,
+		},
 		"node_count": schema.Int64Attribute{
 			Optional: true,
 			Computed: true,
@@ -860,11 +863,12 @@ func getManagedRegions(apiRegions *[]client.Region, plan []Region) []Region {
 	for _, x := range *apiRegions {
 		if isDatasourceOrImport || planRegions[x.Name] {
 			rg := Region{
-				Name:      types.StringValue(x.Name),
-				SqlDns:    types.StringValue(x.SqlDns),
-				UiDns:     types.StringValue(x.UiDns),
-				NodeCount: types.Int64Value(int64(x.NodeCount)),
-				Primary:   types.BoolValue(x.GetPrimary()),
+				Name:        types.StringValue(x.Name),
+				SqlDns:      types.StringValue(x.SqlDns),
+				UiDns:       types.StringValue(x.UiDns),
+				InternalDns: types.StringValue(x.InternalDns),
+				NodeCount:   types.Int64Value(int64(x.NodeCount)),
+				Primary:     types.BoolValue(x.GetPrimary()),
 			}
 			regions = append(regions, rg)
 		}

--- a/internal/provider/cockroach_cluster_data_source.go
+++ b/internal/provider/cockroach_cluster_data_source.go
@@ -111,6 +111,9 @@ func (d *clusterDataSource) Schema(
 						"ui_dns": schema.StringAttribute{
 							Computed: true,
 						},
+						"internal_dns": schema.StringAttribute{
+							Computed: true,
+						},
 						"node_count": schema.Int64Attribute{
 							Computed: true,
 						},

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -29,11 +29,12 @@ const (
 )
 
 type Region struct {
-	Name      types.String `tfsdk:"name"`
-	SqlDns    types.String `tfsdk:"sql_dns"`
-	UiDns     types.String `tfsdk:"ui_dns"`
-	NodeCount types.Int64  `tfsdk:"node_count"`
-	Primary   types.Bool   `tfsdk:"primary"`
+	Name        types.String `tfsdk:"name"`
+	SqlDns      types.String `tfsdk:"sql_dns"`
+	UiDns       types.String `tfsdk:"ui_dns"`
+	InternalDns types.String `tfsdk:"internal_dns"`
+	NodeCount   types.Int64  `tfsdk:"node_count"`
+	Primary     types.Bool   `tfsdk:"primary"`
 }
 
 type DedicatedClusterConfig struct {


### PR DESCRIPTION
Previously, there was no way to obtain the internal_dns field via the
terraform provider; the CC API does return the internal_dns field. This
commit updates the provider to include that field so that users could use it
for VPC Peering or AWS PrivateLink.