### PR TITLE
[CC-52142] Add tests for data sources and resource import

### DIFF
--- a/internal/provider/client_ca_cert_resource_test.go
+++ b/internal/provider/client_ca_cert_resource_test.go
@@ -135,7 +135,7 @@ func TestIntegrationClientCACertResource(t *testing.T) {
 	s.EXPECT().GetCluster(gomock.Any(), clusterId).
 		Return(cluster, httpOkResponse, nil) // CLUSTER Read()
 	s.EXPECT().GetClientCACert(gomock.Any(), clusterId).
-		Return(cert2InfoReady, nil, nil) // CERT Read()
+		Return(cert2InfoReady, nil, nil).Times(2) // CERT Read()
 
 	s.EXPECT().DeleteClientCACert(gomock.Any(), clusterId).
 		Return(certInfoEmptyPending, nil, nil) // CERT Delete()
@@ -173,6 +173,11 @@ func testClientCACertResource(t *testing.T, clusterName string, cert1 string, ce
 					resource.TestCheckResourceAttr(cliCACertResourceName, "x509_pem_cert", cert2),
 					resource.TestCheckResourceAttr(cliCACertResourceName, "status", string(client.CLIENTCACERTSTATUS_IS_SET)),
 				),
+			},
+			{
+				ImportState:       true,
+				ImportStateVerify: true,
+				ResourceName:      cliCACertResourceName,
 			},
 		},
 	})

--- a/internal/provider/cluster_cert_data_source.go
+++ b/internal/provider/cluster_cert_data_source.go
@@ -69,7 +69,7 @@ func (d *clusterCertDataSource) Configure(_ context.Context, req datasource.Conf
 	}
 }
 
-func downloadCert(cluster *client.Cluster, diags *diag.Diagnostics) []byte {
+var DownloadClusterCert = func(cluster *client.Cluster, diags *diag.Diagnostics) []byte {
 	serverURL := client.DefaultServerURL
 	if value, found := os.LookupEnv(APIServerURLKey); found {
 		serverURL = value
@@ -107,7 +107,7 @@ func (d *clusterCertDataSource) Read(ctx context.Context, req datasource.ReadReq
 		return
 	}
 
-	certContents := downloadCert(cluster, &resp.Diagnostics)
+	certContents := DownloadClusterCert(cluster, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/cluster_cert_data_source_test.go
+++ b/internal/provider/cluster_cert_data_source_test.go
@@ -1,0 +1,121 @@
+/*
+ Copyright 2023 The Cockroach Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
+	mock_client "github.com/cockroachdb/terraform-provider-cockroach/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccClusterCertResource attempts to download a cluster's cert.
+// It will be skipped if TF_ACC isn't set.
+func TestAccClusterCertDataSource(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tftest-cert-%s", GenerateRandomString(4))
+
+	testClusterCertDataSource(t, clusterName, false)
+}
+
+func TestIntegrationClusterCertDataSource(t *testing.T) {
+	clusterName := fmt.Sprintf("tftest-cert-%s", GenerateRandomString(4))
+	clusterId := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+	var numDownloads int
+	defer HookGlobal(&DownloadClusterCert, func(_ *client.Cluster, _ *diag.Diagnostics) []byte {
+		numDownloads++
+		return []byte("Hark, a cert")
+	})()
+
+	cluster := &client.Cluster{
+		Id:            clusterId,
+		Name:          clusterName,
+		CloudProvider: "GCP",
+		State:         "CREATED",
+		Config: client.ClusterConfig{
+			Serverless: &client.ServerlessClusterConfig{},
+		},
+		Regions: []client.Region{
+			{
+				Name: "us-central1",
+			},
+		},
+	}
+
+	httpOkResponse := &http.Response{Status: http.StatusText(http.StatusOK)}
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+		Return(cluster, nil, nil)
+	s.EXPECT().GetCluster(gomock.Any(), clusterId).
+		Return(cluster, httpOkResponse, nil).Times(6)
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterId)
+
+	testClusterCertDataSource(t, clusterName, true)
+	require.Equal(t, 4, numDownloads)
+}
+
+func testClusterCertDataSource(t *testing.T, clusterName string, useMock bool) {
+	certDataSourceName := "data.cockroach_cluster_cert.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               useMock,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestClusterCertDataSourceConfig(clusterName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(certDataSourceName, "cert"),
+				),
+			},
+		},
+	})
+}
+
+func getTestClusterCertDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+	name           = "%s"
+	cloud_provider = "GCP"
+	serverless = {}
+	regions = [{
+		name = "us-central1"
+	}]
+}
+
+data "cockroach_cluster_cert" "test" {
+	id = cockroach_cluster.test.id
+}
+`, name)
+}

--- a/internal/provider/cmek_resource_test.go
+++ b/internal/provider/cmek_resource_test.go
@@ -202,7 +202,7 @@ func TestIntegrationCMEKResource(t *testing.T) {
 		Return(initialCluster, nil, nil).
 		Times(2)
 	s.EXPECT().GetCMEKClusterInfo(gomock.Any(), clusterID).
-		Return(initialCMEKInfo, nil, nil)
+		Return(initialCMEKInfo, nil, nil).Times(2)
 	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, clusterUpdateSpec).
 		Return(updatedCluster, nil, nil)
 	s.EXPECT().GetCluster(gomock.Any(), clusterID).
@@ -234,6 +234,12 @@ func testCMEKResource(t *testing.T, clusterName string, useMock bool) {
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCockroachClusterExists(clusterResourceName),
 				),
+			},
+			{
+				// Test import functionality here, because an imported CMEK resource won't have additional_regions.
+				ResourceName:      cmekResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: getTestCMEKResourceUpdateConfig(clusterName),

--- a/internal/provider/connection_string_data_source_test.go
+++ b/internal/provider/connection_string_data_source_test.go
@@ -1,0 +1,145 @@
+/*
+ Copyright 2023 The Cockroach Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
+	mock_client "github.com/cockroachdb/terraform-provider-cockroach/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccConnectionStringDataSource attempts to retrieve a cluster's
+// connection string. It will be skipped if TF_ACC isn't set.
+func TestAccConnectionStringDataSource(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tftest-connect-%s", GenerateRandomString(4))
+
+	testConnectionStringDataSource(t, clusterName, false)
+}
+
+func TestIntegrationConnectionStringDataSource(t *testing.T) {
+	clusterName := fmt.Sprintf("tftest-connect-%s", GenerateRandomString(4))
+	clusterId := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	cluster := &client.Cluster{
+		Id:            clusterId,
+		Name:          clusterName,
+		CloudProvider: "GCP",
+		State:         "CREATED",
+		Config: client.ClusterConfig{
+			Serverless: &client.ServerlessClusterConfig{},
+		},
+		Regions: []client.Region{
+			{
+				Name: "us-central1",
+			},
+		},
+	}
+
+	db, sqlUser, os := "testdb", "test", "MAC"
+	connectStringOptions := &client.GetConnectionStringOptions{
+		Database: &db,
+		SqlUser:  &sqlUser,
+		Os:       &os,
+	}
+	fakeString := "postgresql://test@fake.cockroachlabs.cloud:26257/testdb"
+	connectionStringResponse := &client.GetConnectionStringResponse{
+		ConnectionString: &fakeString,
+		Params:           &map[string]string{},
+	}
+
+	httpOkResponse := &http.Response{Status: http.StatusText(http.StatusOK)}
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+		Return(cluster, nil, nil)
+	s.EXPECT().GetCluster(gomock.Any(), clusterId).
+		Return(cluster, httpOkResponse, nil).Times(2)
+	s.EXPECT().GetConnectionString(gomock.Any(), clusterId, connectStringOptions).
+		Return(connectionStringResponse, httpOkResponse, nil).Times(4)
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterId)
+
+	testConnectionStringDataSource(t, clusterName, true)
+}
+
+func testConnectionStringDataSource(t *testing.T, clusterName string, useMock bool) {
+	connectStrDataSourceName := "data.cockroach_connection_string.test"
+	sqlPassword := "hunter2"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               useMock,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestConnectionStringResourceConfig(clusterName, sqlPassword),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(connectStrDataSourceName, "connection_string"),
+					resource.TestCheckResourceAttrSet(connectStrDataSourceName, "connection_params.%"),
+					resource.TestCheckResourceAttrWith(connectStrDataSourceName, "connection_string", func(value string) error {
+						connectURL, err := url.Parse(value)
+						if err != nil {
+							return err
+						}
+						if _, ok := connectURL.User.Password(); !ok {
+							return errors.New("password missing from connection string")
+						}
+						return nil
+					}),
+				),
+			},
+		},
+	})
+}
+
+func getTestConnectionStringResourceConfig(name, sqlPassword string) string {
+	return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+	name           = "%s"
+	cloud_provider = "GCP"
+	serverless = {}
+	regions = [{
+		name = "us-central1"
+	}]
+}
+
+data "cockroach_connection_string" "test" {
+	id = cockroach_cluster.test.id
+	os = "MAC"
+	database = "testdb"
+	sql_user = "test"
+	password = "%s"
+}
+`, name, sqlPassword)
+}

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -108,7 +108,7 @@ func TestIntegrationDatabaseResource(t *testing.T) {
 		Return(&updatedDatabase, nil, nil)
 	s.EXPECT().ListDatabases(gomock.Any(), clusterID, gomock.Any()).
 		Return(&client.ApiListDatabasesResponse{Databases: []client.ApiDatabase{updatedDatabase}}, nil, nil).
-		Times(2)
+		Times(3)
 
 	// Delete
 	s.EXPECT().DeleteDatabase(gomock.Any(), clusterID, newDatabaseName)
@@ -143,6 +143,11 @@ func testDatabaseResource(
 					testDatabaseExists(resourceName, clusterResourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", newDatabaseName),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/log_export_config_resource_test.go
+++ b/internal/provider/log_export_config_resource_test.go
@@ -159,7 +159,7 @@ func TestIntegrationLogExportConfigResource(t *testing.T) {
 		Return(updatedLogExportClusterInfo, nil, nil)
 	s.EXPECT().GetLogExportInfo(gomock.Any(), clusterID).
 		Return(updatedLogExportClusterInfo, nil, nil).
-		Times(3)
+		Times(4)
 
 	// Delete
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
@@ -196,6 +196,11 @@ func testLogExportConfigResource(t *testing.T, clusterName string, useMock bool)
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.#", "2"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.0.channels.#", "1"),
 				),
+			},
+			{
+				ResourceName:      logExportConfigResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/maintenance_window_test.go
+++ b/internal/provider/maintenance_window_test.go
@@ -103,7 +103,8 @@ func TestIntegrationMaintenanceWindowResource(t *testing.T) {
 	s.EXPECT().SetMaintenanceWindow(gomock.Any(), clusterID, updatedMaintenanceWindowInfo).
 		Return(updatedMaintenanceWindowInfo, nil, nil)
 	s.EXPECT().GetMaintenanceWindow(gomock.Any(), clusterID).
-		Return(updatedMaintenanceWindowInfo, nil, nil)
+		Return(updatedMaintenanceWindowInfo, nil, nil).
+		Times(2)
 
 	// Delete
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
@@ -138,6 +139,11 @@ func testMaintenanceWindowResource(t *testing.T, clusterName string, useMock boo
 					resource.TestCheckResourceAttr(maintenanceWindowResourceName, "offset_duration", "1100"),
 					resource.TestCheckResourceAttr(maintenanceWindowResourceName, "window_duration", "110011"),
 				),
+			},
+			{
+				ResourceName:      maintenanceWindowResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/metric_export_cloudwatch_config_resource_test.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource_test.go
@@ -133,7 +133,7 @@ func TestIntegrationMetricExportCloudWatchConfigResource(t *testing.T) {
 		Return(updatedCloudWatchClusterInfo, nil, nil)
 	s.EXPECT().GetCloudWatchMetricExportInfo(gomock.Any(), clusterID).
 		Return(updatedCloudWatchClusterInfo, nil, nil).
-		Times(3)
+		Times(4)
 
 	// Delete
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
@@ -170,6 +170,11 @@ func testMetricExportCloudWatchConfigResource(t *testing.T, clusterName string, 
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "log_group_name", "example"),
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "target_region", "us-east-1"),
 				),
+			},
+			{
+				ResourceName:      metricExportCloudWatchConfigResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/metric_export_datadog_config_resource_test.go
+++ b/internal/provider/metric_export_datadog_config_resource_test.go
@@ -131,7 +131,7 @@ func TestIntegrationMetricExportDatadogConfigResource(t *testing.T) {
 		Return(updatedDatadogClusterInfo, nil, nil)
 	s.EXPECT().GetDatadogMetricExportInfo(gomock.Any(), clusterID).
 		Return(updatedDatadogClusterInfo, nil, nil).
-		Times(3)
+		Times(4)
 
 	// Delete
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
@@ -168,6 +168,15 @@ func testMetricExportDatadogConfigResource(t *testing.T, clusterName string, use
 					resource.TestCheckResourceAttr(metricExportDatadogConfigResourceName, "api_key", "test-api-key-updated"),
 					resource.TestCheckResourceAttr(metricExportDatadogConfigResourceName, "status", "ENABLED"),
 				),
+			},
+			{
+				ResourceName:      metricExportDatadogConfigResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// The API key gets redacted and truncated by the API server.
+					"api_key",
+				},
 			},
 		},
 	})

--- a/internal/provider/networking_resource_test.go
+++ b/internal/provider/networking_resource_test.go
@@ -206,7 +206,7 @@ func TestIntegrationAllowlistEntryResource(t *testing.T) {
 				Return(&newEntry, &http.Response{Status: http.StatusText(http.StatusOK)}, nil)
 			s.EXPECT().ListAllowlistEntries(gomock.Any(), clusterID, gomock.Any()).
 				Return(&client.ListAllowlistEntriesResponse{Allowlist: []client.AllowlistEntry{otherEntry, newEntry}}, nil, nil).
-				Times(2)
+				Times(3)
 
 			// Delete
 			s.EXPECT().DeleteAllowlistEntry(gomock.Any(), clusterID, entry.CidrIp, entry.CidrMask)
@@ -267,6 +267,11 @@ func testAllowlistEntryResource(
 					resource.TestCheckResourceAttr(resourceName, "ui", "false"),
 					resource.TestCheckResourceAttr(resourceName, "sql", "false"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/organization_data_source_test.go
+++ b/internal/provider/organization_data_source_test.go
@@ -1,0 +1,84 @@
+/*
+ Copyright 2023 The Cockroach Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package provider
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
+	mock_client "github.com/cockroachdb/terraform-provider-cockroach/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccOrganizationDataSource attempts to read organzation info for
+// the current API key. It will be skipped if TF_ACC isn't set.
+func TestAccOrganizationDataSource(t *testing.T) {
+	t.Parallel()
+
+	testOrganizationDataSource(t, false)
+}
+
+func TestIntegrationOrganizationDataSource(t *testing.T) {
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	s.EXPECT().GetOrganizationInfo(gomock.Any()).
+		Return(&client.Organization{
+			CreatedAt: time.Now(),
+			Id:        "org-id",
+			Label:     "org-label",
+			Name:      "org-name",
+		}, nil, nil).
+		Times(5)
+
+	testOrganizationDataSource(t, true)
+}
+
+func testOrganizationDataSource(t *testing.T, useMock bool) {
+	orgDataSourceName := "data.cockroach_organization.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               useMock,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestOrganizationDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(orgDataSourceName, "id"),
+					resource.TestCheckResourceAttrSet(orgDataSourceName, "label"),
+					resource.TestCheckResourceAttrSet(orgDataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(orgDataSourceName, "created_at"),
+				),
+			},
+		},
+	})
+}
+
+func getTestOrganizationDataSourceConfig() string {
+	return `data "cockroach_organization" "test" {}`
+}

--- a/internal/provider/person_user_data_source_test.go
+++ b/internal/provider/person_user_data_source_test.go
@@ -1,0 +1,79 @@
+/*
+ Copyright 2023 The Cockroach Authors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
+	mock_client "github.com/cockroachdb/terraform-provider-cockroach/mock"
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestIntegrationPersonUserDataSource(t *testing.T) {
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	email := "test@cockroachlabs.com"
+
+	s.EXPECT().GetPersonUsersByEmail(gomock.Any(), &email).
+		Return(&client.GetPersonUsersByEmailResponse{
+			User: &client.PersonUserInfo{
+				Email: &email,
+				Id:    "test-id",
+			},
+		}, nil, nil).
+		Times(5)
+
+	testPersonUserDataSource(t, email, true)
+}
+
+func testPersonUserDataSource(t *testing.T, email string, useMock bool) {
+	dataSourceName := "data.cockroach_person_user.test"
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               useMock,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: getTestPersonUserDataSourceConfig(email),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "id"),
+					resource.TestCheckResourceAttr(dataSourceName, "email", email),
+				),
+			},
+		},
+	})
+}
+
+func getTestPersonUserDataSourceConfig(email string) string {
+	return fmt.Sprintf(
+		`data "cockroach_person_user" "test" {
+		email = "%s"
+	}`, email)
+}

--- a/internal/provider/private_endpoint_connection_resource_test.go
+++ b/internal/provider/private_endpoint_connection_resource_test.go
@@ -159,7 +159,7 @@ func TestIntegrationPrivateEndpointConnectionResource(t *testing.T) {
 				Return(&connection, nil, nil)
 			s.EXPECT().ListAwsEndpointConnections(gomock.Any(), clusterID).
 				Return(connections, nil, nil).
-				Times(2)
+				Times(3)
 			rejected := client.SETAWSENDPOINTCONNECTIONSTATUSTYPE_REJECTED
 			s.EXPECT().SetAwsEndpointConnectionState(
 				gomock.Any(),
@@ -205,6 +205,11 @@ func testPrivateEndpointConnectionResource(
 					resource.TestCheckResourceAttr(resourceName, "region_name", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "cloud_provider", "AWS"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/private_endpoint_services_resource_test.go
+++ b/internal/provider/private_endpoint_services_resource_test.go
@@ -156,7 +156,7 @@ func TestIntegrationPrivateEndpointServicesResource(t *testing.T) {
 			}
 			s.EXPECT().ListPrivateEndpointServices(gomock.Any(), clusterID).
 				Return(services, nil, nil).
-				Times(2)
+				Times(3)
 			s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
 
 			testPrivateEndpointServicesResource(
@@ -172,6 +172,7 @@ func TestIntegrationPrivateEndpointServicesResource(t *testing.T) {
 func testPrivateEndpointServicesResource(
 	t *testing.T, clusterName string, useMock bool, isServerless bool,
 ) {
+	resourceName := "cockroach_private_endpoint_services.services"
 	var clusterResourceName string
 	var privateEndpointServicesResourceConfigFn func(string) string
 	var numExpectedServices int
@@ -187,11 +188,11 @@ func testPrivateEndpointServicesResource(
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(clusterResourceName, "name", clusterName),
-		resource.TestCheckResourceAttr("cockroach_private_endpoint_services.services", "services.#", strconv.Itoa(numExpectedServices)),
+		resource.TestCheckResourceAttr(resourceName, "services.#", strconv.Itoa(numExpectedServices)),
 	}
 	for i := 0; i < numExpectedServices; i++ {
 		checks = append(checks,
-			resource.TestCheckResourceAttr("cockroach_private_endpoint_services.services", fmt.Sprintf("services.%d.status", i), string(client.PRIVATEENDPOINTSERVICESTATUSTYPE_AVAILABLE)),
+			resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("services.%d.status", i), string(client.PRIVATEENDPOINTSERVICESTATUSTYPE_AVAILABLE)),
 		)
 	}
 
@@ -203,6 +204,11 @@ func testPrivateEndpointServicesResource(
 			{
 				Config: privateEndpointServicesResourceConfigFn(clusterName),
 				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -120,7 +120,7 @@ func TestIntegrationRoleResource(t *testing.T) {
 	s.EXPECT().SetRolesForUser(gomock.Any(), userId, gomock.Any()).
 		Return(nil, nil, nil)
 	s.EXPECT().ListRoleGrants(gomock.Any(), gomock.Any()).
-		Return(&listResponse, nil, nil)
+		Return(&listResponse, nil, nil).Times(2)
 	s.EXPECT().SetRolesForUser(gomock.Any(), userId, &client.CockroachCloudSetRolesForUserRequest{}).
 		Return(nil, nil, nil)
 
@@ -145,6 +145,11 @@ func testRoleResource(t *testing.T, userId string, useMock bool) {
 					testRoleMembership(resourceNameTest, userId, "CLUSTER_ADMIN", true),
 					resource.TestCheckResourceAttr(resourceNameTest, "id", userId),
 				),
+			},
+			{
+				ResourceName:      resourceNameTest,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/internal/provider/sql_user_resource_test.go
+++ b/internal/provider/sql_user_resource_test.go
@@ -100,7 +100,7 @@ func TestIntegrationSqlUserResource(t *testing.T) {
 		clusterID,
 		&client.CreateSQLUserRequest{Name: sqlUserNameNoPass, Password: testPassword},
 	).Return(&userNoPass, nil, nil)
-	s.EXPECT().ListSQLUsers(gomock.Any(), clusterID, gomock.Any()).Times(4).Return(
+	s.EXPECT().ListSQLUsers(gomock.Any(), clusterID, gomock.Any()).Times(5).Return(
 		&client.ListSQLUsersResponse{Users: []client.SQLUser{userWithPass, userNoPass}}, nil, nil)
 	s.EXPECT().DeleteSQLUser(gomock.Any(), clusterID, userWithPass.Name)
 	s.EXPECT().DeleteSQLUser(gomock.Any(), clusterID, userNoPass.Name)
@@ -133,6 +133,14 @@ func testSqlUserResource(
 					resource.TestCheckResourceAttr(resourceNamePass, "name", sqlUserNameWithPass),
 					resource.TestCheckResourceAttr(resourceNameNoPass, "name", sqlUserNameNoPass),
 				),
+			},
+			{
+				ResourceName:      resourceNamePass,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
 			},
 		},
 	})

--- a/internal/provider/version_deferral_test.go
+++ b/internal/provider/version_deferral_test.go
@@ -101,7 +101,8 @@ func TestIntegrationVersionDeferralResource(t *testing.T) {
 	s.EXPECT().SetClusterVersionDeferral(gomock.Any(), clusterID, updatedVersionDeferralInfo).
 		Return(updatedVersionDeferralInfo, nil, nil)
 	s.EXPECT().GetClusterVersionDeferral(gomock.Any(), clusterID).
-		Return(updatedVersionDeferralInfo, nil, nil)
+		Return(updatedVersionDeferralInfo, nil, nil).
+		Times(2)
 
 	// Delete
 	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
@@ -134,6 +135,11 @@ func testVersionDeferralResource(t *testing.T, clusterName string, useMock bool)
 					testCheckCockroachClusterExists(clusterResourceName),
 					resource.TestCheckResourceAttr(versionDeferralResourceName, "deferral_policy", "NOT_DEFERRED"),
 				),
+			},
+			{
+				ResourceName:      versionDeferralResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})


### PR DESCRIPTION
Made sure all resources and data sources have tests. Added import steps to resources that didn't already have one.

**Commit checklist**
- [n/a] Changelog
- [n/a] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [n/a] Example(s)
