### PR TITLE
[CC-25232] Use plan instead of config

### DIFF
--- a/internal/provider/client_ca_cert_resource.go
+++ b/internal/provider/client_ca_cert_resource.go
@@ -85,7 +85,7 @@ func (r *clientCACertResource) Create(ctx context.Context, req resource.CreateRe
 
 	// Retrieve values from plan
 	var plan ClientCACertResourceModel
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -274,7 +274,7 @@ func (r *clusterResource) Create(
 
 	var plan CockroachCluster
 
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cmek_resource.go
+++ b/internal/provider/cmek_resource.go
@@ -139,7 +139,7 @@ func (r *cmekResource) Create(
 
 	var plan ClusterCMEK
 
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -93,7 +93,7 @@ func TestIntegrationDatabaseResource(t *testing.T) {
 		gomock.Any(),
 		clusterID,
 		&client.CreateDatabaseRequest{Name: databaseName},
-	).Return(nil, nil, nil)
+	).Return(&database, nil, nil)
 	s.EXPECT().ListDatabases(gomock.Any(), clusterID, gomock.Any()).
 		Return(&client.ApiListDatabasesResponse{Databases: []client.ApiDatabase{database}}, nil, nil).
 		Times(2)

--- a/internal/provider/log_export_config_resource.go
+++ b/internal/provider/log_export_config_resource.go
@@ -145,7 +145,7 @@ func (r *logExportConfigResource) Create(
 
 	var plan ClusterLogExport
 
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/maintenance_window.go
+++ b/internal/provider/maintenance_window.go
@@ -88,7 +88,7 @@ func (r *maintenanceWindowResource) Create(
 	}
 
 	var plan ClusterMaintenanceWindow
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/metric_export_cloudwatch_config_resource.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource.go
@@ -105,7 +105,7 @@ func (r *metricExportCloudWatchConfigResource) Create(
 	}
 
 	var plan ClusterCloudWatchMetricExportConfig
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/metric_export_datadog_config_resource.go
+++ b/internal/provider/metric_export_datadog_config_resource.go
@@ -100,7 +100,7 @@ func (r *metricExportDatadogConfigResource) Create(
 	}
 
 	var plan ClusterDatadogMetricExportConfig
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -113,9 +113,9 @@ type PrivateEndpointService struct {
 }
 
 type PrivateEndpointServices struct {
-	ClusterID types.String             `tfsdk:"cluster_id"`
-	Services  []PrivateEndpointService `tfsdk:"services"`
-	ID        types.String             `tfsdk:"id"`
+	ClusterID types.String `tfsdk:"cluster_id"`
+	Services  types.List   `tfsdk:"services"`
+	ID        types.String `tfsdk:"id"`
 }
 
 type PrivateEndpointConnection struct {

--- a/internal/provider/networking_resource.go
+++ b/internal/provider/networking_resource.go
@@ -118,7 +118,7 @@ func (r *allowListResource) Create(
 	}
 
 	var entry AllowlistEntry
-	diags := req.Config.Get(ctx, &entry)
+	diags := req.Plan.Get(ctx, &entry)
 	resp.Diagnostics.Append(diags...)
 	// Create a unique ID (required by terraform framework) by combining
 	// the cluster ID and full CIDR address.

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -119,7 +119,7 @@ func (r *privateEndpointConnectionResource) Create(
 	}
 
 	var plan PrivateEndpointConnection
-	diags := req.Config.Get(ctx, &plan)
+	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -152,12 +152,6 @@ func (r *privateEndpointConnectionResource) Create(
 			"Error establishing AWS Endpoint Connection",
 			fmt.Sprintf("Could not establish AWS Endpoint Connection: %s", formatAPIErrorMessage(err)),
 		)
-		return
-	}
-
-	diags = resp.State.Set(ctx, plan)
-	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
 		return
 	}
 

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -99,7 +99,7 @@ func (r *roleResource) Create(
 	}
 
 	var roleGrantSpec RoleGrant
-	diags := req.Config.Get(ctx, &roleGrantSpec)
+	diags := req.Plan.Get(ctx, &roleGrantSpec)
 	resp.Diagnostics.Append(diags...)
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/sql_user_resource.go
+++ b/internal/provider/sql_user_resource.go
@@ -128,7 +128,7 @@ func (r *sqlUserResource) Create(
 	}
 
 	var sqlUserSpec SQLUser
-	diags := req.Config.Get(ctx, &sqlUserSpec)
+	diags := req.Plan.Get(ctx, &sqlUserSpec)
 	resp.Diagnostics.Append(diags...)
 	// Create a unique ID (required by terraform framework) by combining
 	// the cluster ID and username.

--- a/internal/provider/version_deferral.go
+++ b/internal/provider/version_deferral.go
@@ -79,7 +79,7 @@ func (r *versionDeferralResource) Create(
 	}
 
 	var versionDeferral ClusterVersionDeferral
-	diags := req.Config.Get(ctx, &versionDeferral)
+	diags := req.Plan.Get(ctx, &versionDeferral)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return


### PR DESCRIPTION
For most resources, this is a simple find & replace.

For the database resource, I had it read the database from the create response and load it into the state instead of copying the plan (which can contain unknowns).

Private endpoint services is a weird case. Apparently, Terraform doesn't like it when Unknown values are loaded into non-Terraform types. Thankfully, this is only a problem for fully computed attributes. Required and optional attributes are loaded as nil. To resolve this, though, I had to change the data type for `services` to `types.List` and pass in the exact schema type to its constructor. I pulled the schema object out of the Schema method so I could extract the attribute type without dupicating code.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
