### PR TITLE
Check both IsNull and IsUnknown in plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue where changing `num_virtual_cpus` on a `cockroach_cluster` resource would fail to scale the cluster
+  and would result in an inconsistent state error.
+
 ## [0.7.0] - 2023-07-13
 
 ### Added

--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -49,10 +49,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "num_virtual_cpus" {
+  type     = number
   nullable = false
-  default  = "n1-standard-2"
+  default  = 2
 }
 
 variable "allow_list_name" {
@@ -101,8 +101,8 @@ resource "cockroach_cluster" "example" {
   cloud_provider    = var.cloud_provider
   cockroach_version = var.cockroach_version
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.num_virtual_cpus
   }
   regions = [
     for r in var.cloud_provider_regions : {

--- a/internal/provider/allowlist_resource.go
+++ b/internal/provider/allowlist_resource.go
@@ -142,7 +142,7 @@ func (r *allowListResource) Create(
 		Sql:      entry.Sql.ValueBool(),
 	}
 
-	if !entry.Name.IsNull() {
+	if IsKnown(entry.Name) {
 		name := entry.Name.ValueString()
 		allowList.Name = &name
 	}

--- a/internal/provider/client_ca_cert_resource.go
+++ b/internal/provider/client_ca_cert_resource.go
@@ -177,8 +177,8 @@ func (r *clientCACertResource) Update(ctx context.Context, req resource.UpdateRe
 
 	// Only update cert if non-null.
 	// Setting it to null will essentially cause TF to forget the field.
-	if plan.X509PemCert.IsNull() {
-		if !state.X509PemCert.IsNull() {
+	if !IsKnown(plan.X509PemCert) {
+		if IsKnown(state.X509PemCert) {
 			resp.Diagnostics.AddWarning(
 				"Client CA Cert will not be changed",
 				"Setting the cert field to null will not clear the cert, it will only remove it from Terraform state. Delete the resource to unset a cert.",

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -327,7 +327,7 @@ func (r *clusterResource) Create(
 				usageLimits.RequestUnitLimit.ValueInt64(), usageLimits.StorageMibLimit.ValueInt64())
 		} else {
 			spendLimit := plan.ServerlessConfig.SpendLimit
-			if !spendLimit.IsNull() {
+			if IsKnown(spendLimit) {
 				val := int32(spendLimit.ValueInt64())
 				serverless.SpendLimit = &val
 			}
@@ -336,7 +336,7 @@ func (r *clusterResource) Create(
 		clusterSpec.SetServerless(*serverless)
 	} else if plan.DedicatedConfig != nil {
 		dedicated := client.DedicatedClusterCreateSpecification{}
-		if !plan.CockroachVersion.IsNull() {
+		if IsKnown(plan.CockroachVersion) {
 			version := plan.CockroachVersion.ValueString()
 			dedicated.CockroachVersion = &version
 		}
@@ -350,18 +350,18 @@ func (r *clusterResource) Create(
 		if cfg := plan.DedicatedConfig; cfg != nil {
 			hardware := client.DedicatedHardwareCreateSpecification{}
 			machineSpec := client.DedicatedMachineTypeSpecification{}
-			if !cfg.NumVirtualCpus.IsNull() {
+			if IsKnown(cfg.NumVirtualCpus) {
 				cpus := int32(cfg.NumVirtualCpus.ValueInt64())
 				machineSpec.NumVirtualCpus = &cpus
-			} else if !cfg.MachineType.IsNull() {
+			} else if IsKnown(cfg.MachineType) {
 				machineType := cfg.MachineType.ValueString()
 				machineSpec.MachineType = &machineType
 			}
 			hardware.MachineSpec = machineSpec
-			if !cfg.StorageGib.IsNull() {
+			if IsKnown(cfg.StorageGib) {
 				hardware.StorageGib = int32(cfg.StorageGib.ValueInt64())
 			}
-			if !cfg.DiskIops.IsNull() {
+			if IsKnown(cfg.DiskIops) {
 				diskiops := int32(cfg.DiskIops.ValueInt64())
 				hardware.DiskIops = &diskiops
 			}
@@ -423,7 +423,7 @@ func (r *clusterResource) Read(
 		return
 	}
 
-	if cluster.ID.IsNull() {
+	if !IsKnown(cluster.ID) {
 		return
 	}
 	clusterID := cluster.ID.ValueString()
@@ -559,7 +559,7 @@ func (r *clusterResource) Update(
 	}
 
 	// CRDB Versions
-	if !plan.CockroachVersion.IsNull() && plan.CockroachVersion != state.CockroachVersion {
+	if IsKnown(plan.CockroachVersion) && plan.CockroachVersion != state.CockroachVersion {
 		// Validate that the target version is valid.
 		planVersion := plan.CockroachVersion.ValueString()
 		stateVersion := state.CockroachVersion.ValueString()
@@ -669,19 +669,19 @@ func (r *clusterResource) Update(
 			}
 		}
 		dedicated.Hardware = client.NewDedicatedHardwareUpdateSpecification()
-		if !plan.DedicatedConfig.StorageGib.IsNull() {
+		if IsKnown(plan.DedicatedConfig.StorageGib) {
 			storage := int32(plan.DedicatedConfig.StorageGib.ValueInt64())
 			dedicated.Hardware.StorageGib = &storage
 		}
-		if !plan.DedicatedConfig.DiskIops.IsNull() {
+		if IsKnown(plan.DedicatedConfig.DiskIops) {
 			diskiops := int32(plan.DedicatedConfig.DiskIops.ValueInt64())
 			dedicated.Hardware.DiskIops = &diskiops
 		}
 		machineSpec := client.DedicatedMachineTypeSpecification{}
-		if !plan.DedicatedConfig.MachineType.IsNull() {
+		if IsKnown(plan.DedicatedConfig.MachineType) {
 			machineType := plan.DedicatedConfig.MachineType.ValueString()
 			machineSpec.MachineType = &machineType
-		} else if !plan.DedicatedConfig.NumVirtualCpus.IsNull() {
+		} else if IsKnown(plan.DedicatedConfig.NumVirtualCpus) {
 			cpus := int32(plan.DedicatedConfig.NumVirtualCpus.ValueInt64())
 			machineSpec.NumVirtualCpus = &cpus
 		}
@@ -734,7 +734,7 @@ func (r *clusterResource) Delete(
 	}
 
 	// Get cluster ID from state
-	if state.ID.IsNull() {
+	if !IsKnown(state.ID) {
 		return
 	}
 	clusterID := state.ID.ValueString()
@@ -850,7 +850,7 @@ func loadClusterToTerraformState(
 				RequestUnitLimit: types.Int64Value(usageLimits.RequestUnitLimit),
 				StorageMibLimit:  types.Int64Value(usageLimits.StorageMibLimit),
 			}
-		} else if clusterObj.Config.Serverless.SpendLimit != nil && planConfig != nil && !planConfig.SpendLimit.IsNull() {
+		} else if clusterObj.Config.Serverless.SpendLimit != nil && planConfig != nil && IsKnown(planConfig.SpendLimit) {
 			serverlessConfig.SpendLimit = types.Int64Value(int64(clusterObj.Config.Serverless.GetSpendLimit()))
 		}
 		state.ServerlessConfig = serverlessConfig

--- a/internal/provider/cmek_resource.go
+++ b/internal/provider/cmek_resource.go
@@ -203,7 +203,7 @@ func (r *cmekResource) Read(
 	var cmek ClusterCMEK
 	diags := req.State.Get(ctx, &cmek)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() || cmek.ID.IsNull() {
+	if resp.Diagnostics.HasError() || !IsKnown(cmek.ID) {
 		return
 	}
 

--- a/internal/provider/connection_string_data_source.go
+++ b/internal/provider/connection_string_data_source.go
@@ -120,12 +120,12 @@ func (d *connectionStringDataSource) Read(
 		database = config.Database.ValueString()
 	}
 	var sqlUser *string
-	if !config.SqlUser.IsNull() {
+	if IsKnown(config.SqlUser) {
 		sqlUser = new(string)
 		*sqlUser = config.SqlUser.ValueString()
 	}
 	var os string
-	if !config.OS.IsNull() {
+	if IsKnown(config.OS) {
 		os = config.OS.ValueString()
 	} else {
 		switch runtime.GOOS {
@@ -154,7 +154,7 @@ func (d *connectionStringDataSource) Read(
 	connectionString := apiResp.GetConnectionString()
 	connectionParams := apiResp.GetParams()
 
-	if !config.Password.IsNull() {
+	if IsKnown(config.Password) {
 		connectionParams["Password"] = config.Password.ValueString()
 		if connectionURL, err := url.Parse(connectionString); err != nil {
 			resp.Diagnostics.AddWarning("Couldn't parse connection URL to inject password", err.Error())

--- a/internal/provider/log_export_config_resource.go
+++ b/internal/provider/log_export_config_resource.go
@@ -344,7 +344,7 @@ func (r *logExportConfigResource) Read(
 	var state ClusterLogExport
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() || state.ID.IsNull() {
+	if resp.Diagnostics.HasError() || !IsKnown(state.ID) {
 		return
 	}
 	clusterID := state.ID.ValueString()
@@ -467,11 +467,11 @@ func logExportGroupToClientGroup(group LogExportGroup) (*client.LogExportGroup, 
 		Channels: channels,
 	}
 
-	if !group.Redact.IsNull() && !group.Redact.IsUnknown() {
+	if IsKnown(group.Redact) {
 		clientGroup.SetRedact(group.Redact.ValueBool())
 	}
 
-	if group.MinLevel.IsNull() {
+	if !IsKnown(group.MinLevel) {
 		clientGroup.SetMinLevel(client.LOGLEVELTYPE_UNSPECIFIED)
 	} else {
 		minLevel, err := client.NewLogLevelTypeFromValue(group.MinLevel.ValueString())
@@ -501,10 +501,10 @@ func loadPlanIntoEnableLogExportRequest(
 
 	req.SetAuthPrincipal(plan.AuthPrincipal.ValueString())
 	req.SetLogName(plan.LogName.ValueString())
-	if !plan.Redact.IsNull() && !plan.Redact.IsUnknown() {
+	if IsKnown(plan.Redact) {
 		req.SetRedact(plan.Redact.ValueBool())
 	}
-	if !plan.Region.IsNull() && !plan.Redact.IsUnknown() {
+	if IsKnown(plan.Region) {
 		req.SetRegion(plan.Region.ValueString())
 	}
 

--- a/internal/provider/metric_export_cloudwatch_config_resource.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource.go
@@ -141,10 +141,10 @@ func (r *metricExportCloudWatchConfigResource) Create(
 	}
 
 	apiRequest := client.NewEnableCloudWatchMetricExportRequest(plan.RoleArn.ValueString())
-	if !plan.TargetRegion.IsNull() && !plan.TargetRegion.IsUnknown() {
+	if IsKnown(plan.TargetRegion) {
 		apiRequest.SetTargetRegion(plan.TargetRegion.ValueString())
 	}
-	if !plan.LogGroupName.IsNull() && !plan.LogGroupName.IsUnknown() {
+	if IsKnown(plan.LogGroupName) {
 		apiRequest.SetLogGroupName(plan.LogGroupName.ValueString())
 	}
 
@@ -278,7 +278,7 @@ func (r *metricExportCloudWatchConfigResource) Read(
 	var state ClusterCloudWatchMetricExportConfig
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() || state.ID.IsNull() {
+	if resp.Diagnostics.HasError() || !IsKnown(state.ID) {
 		return
 	}
 	clusterID := state.ID.ValueString()
@@ -357,10 +357,10 @@ func (r *metricExportCloudWatchConfigResource) Update(
 	}
 
 	apiRequest := client.NewEnableCloudWatchMetricExportRequest(plan.RoleArn.ValueString())
-	if !plan.TargetRegion.IsNull() && !plan.TargetRegion.IsUnknown() {
+	if IsKnown(plan.TargetRegion) {
 		apiRequest.SetTargetRegion(plan.TargetRegion.ValueString())
 	}
-	if !plan.LogGroupName.IsNull() && !plan.LogGroupName.IsUnknown() {
+	if IsKnown(plan.LogGroupName) {
 		apiRequest.SetLogGroupName(plan.LogGroupName.ValueString())
 	}
 

--- a/internal/provider/sql_user_resource.go
+++ b/internal/provider/sql_user_resource.go
@@ -264,7 +264,7 @@ func (r *sqlUserResource) Update(
 	// Only update the password if it's non-null. Setting it to null
 	// will essentially cause Terraform to forget the password.
 	if plan.Password.IsNull() {
-		if !state.Password.IsNull() {
+		if IsKnown(state.Password) {
 			resp.Diagnostics.AddWarning(
 				"Password will not be changed",
 				"Setting the password field to null will not change the password. It will simply remove it from Terraform state.",

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -134,3 +134,13 @@ func formatEnumMarkdownList[T ~string](allowedValues []T) (mdList string) {
 	}
 	return mdList
 }
+
+type Knowable interface {
+	IsUnknown() bool
+	IsNull() bool
+}
+
+// IsKnown is a shortcut that checks in a value is neither null nor unknown.
+func IsKnown[T Knowable](t T) bool {
+	return !t.IsUnknown() && !t.IsNull()
+}


### PR DESCRIPTION
Previously, we used the config instead of the plan for create and update operations and were able to simply check for null values. Now we use the plan, but that means we need to check if values are either null or unknown.

This change adds a utility method that checks both. Replaced all references to both states, since in all existing cases, we want to treat them the same.

Refactored the cluster resource integration tests to allow any number of GetCluster calls and return the latest iteration of the cluster after UpdateCluster mutates it.

This fixes issue #152.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
