### PR TITLE
Fix TestAccMultiRegionServerlessClusterResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed an issue where changing `num_virtual_cpus` on a `cockroach_cluster` resource would fail to scale the cluster
   and would result in an inconsistent state error.
+- Added validation to prevent multiple serverless regions from being marked as "primary", which could result in an
+  inconsistent state error.
 
 ## [0.7.0] - 2023-07-13
 


### PR DESCRIPTION
Previously, the primary_region field used a `UseStateForUnknown` plan modifier, but that wasn't actually doing anything because we were checking the config instead of the plan. Now that we're checking the plan instead, the modifier is retaining the attribute's previous value when unknown (removed from the config). That was causing the previous primary region to still be marked as primary, and there was no validation to ensure that only one primary region is specified.

This change removes the plan modifier and adds validation to protect against multiple primaries.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
