### PR TITLE
.github/workflows: split release into pre-release-ci and release (manual)

### DIFF
--- a/.github/workflows/pre-release-ci.yaml
+++ b/.github/workflows/pre-release-ci.yaml
@@ -1,0 +1,25 @@
+name: pre-release-ci
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  acceptance-test:
+    name: acceptance-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: Tests
+        run: make testacc
+        env:
+          COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 # This GitHub action can publish assets for release when a tag is created.
-# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+# Currently its setup to be triggered manually via the GitHUB UI. We should
+# only run this on a tag that matches the pattern "v*" (ie. v0.1.0) *after*
+# validating that the release can be signed off (e.g. by triaging the
+# pre-release-ci workflow).
 #
 # This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your 
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
@@ -8,38 +11,12 @@
 #
 # You will need to pass the `--batch` flag to `gpg` in your signing step 
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
-#
-name: release
-on:
-  push:
-    tags:
-      - 'v*'
+name: release (manually, after pre-release-ci)
+on: workflow_dispatch
 permissions:
   contents: write
 jobs:
-  # pre job to run acceptance tests
-  acceptance-test:
-    name: acceptance-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-        with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18
-
-      - name: Tests
-        run: make testacc
-        env:
-          COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}
-
   goreleaser:
-    needs: acceptance-test
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
Previously, we run the release workflow automatically whenever a v* tag
gets pushed. The existing workflow does not work because the tests can be
flaky. When that happens, there's no way to release a new TF version since
goreleaser will only run once all the acceptance tests pass.

Until the flakiness goes away, we will split the release workflow into
two: pre-release-ci (that runs automatically like before), and release (which
has to be triggered manually after all the acceptance tests are triaged).

**Commit checklist**
- [X] Changelog -- irrelevant
- [X] Doc gen (`make generate`) -- irrelevant
- [X] Integration test(s) -- irrelevant
- [X] Acceptance test(s) -- irrelevant
- [X] Example(s) -- irrelevant
