### PR TITLE
Remove cockroach_version from the dedicated example

### DIFF
--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -19,12 +19,6 @@ variable "sql_user_password" {
   sensitive = true
 }
 
-variable "cockroach_version" {
-  type     = string
-  nullable = true
-  default  = "v22.2"
-}
-
 variable "cloud_provider" {
   type     = string
   nullable = false
@@ -99,7 +93,6 @@ provider "cockroach" {
 resource "cockroach_cluster" "example" {
   name              = var.cluster_name
   cloud_provider    = var.cloud_provider
-  cockroach_version = var.cockroach_version
   dedicated = {
     storage_gib      = var.storage_gib
     num_virtual_cpus = var.num_virtual_cpus


### PR DESCRIPTION
cockroach_version requires a feature flag to be set even if the version is set to the latest version.  Customers who use this example nearly always run into this issue. Removing this block since its not core to the example.

For now, I've left out any docs changes.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
