### PR TITLE
defer to base retry check when response is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a nil pointer exception which could occur while retrying a certain
+  class of api failures.
+
 ## [1.3.0] - 2023-09-14
 
 ### Added

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -84,7 +84,7 @@ var uuidRegex = regexp.MustCompile(uuidRegexString)
 
 // retryGetRequests implements the retryable-http CheckRetry type.
 func retryGetRequestsOnly(ctx context.Context, resp *http.Response, err error) (bool, error) {
-	if resp.Request.Method != http.MethodGet {
+	if resp != nil && resp.Request != nil && resp.Request.Method != http.MethodGet {
 		// We don't want to blindly retry anything that isn't a GET method
 		// because it's possible that a different method type mutated data on
 		// the server even if the response wasn't successful. Application code


### PR DESCRIPTION
We use a custom retryable http client to retry GET requests. Since it is intended to only retry GET requests we check that the request was a GET at the beginning of the method.  The only way to access the request at this point in the code is through the response object, however, there are some cases where this  object is nil.  This was resulting in a nil pointer exception.

After this change, any errors that are seen without a set Response object will fall through to the default handler.

Fixes a Nil pointer exception reported here:
https://cockroachlabs.slack.com/archives/C01J7MGJ3S7/p1696613858625329?thread_ts=1696613850.476459&cid=C01J7MGJ3S7

**Commit checklist**
- ✔️  Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
