### PR TITLE
log-export: make group specific redact noncomputed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a nil pointer exception which could occur while retrying a certain
   class of api failures.
+- Fixed a bug where the `log_export_config` would sometimes fail to detect changes to
+  the group level `redact` field due to it being declared as a `computed` field.
 
 ## [1.3.0] - 2023-09-14
 

--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -91,8 +91,8 @@ provider "cockroach" {
 }
 
 resource "cockroach_cluster" "example" {
-  name              = var.cluster_name
-  cloud_provider    = var.cloud_provider
+  name           = var.cluster_name
+  cloud_provider = var.cloud_provider
   dedicated = {
     storage_gib      = var.storage_gib
     num_virtual_cpus = var.num_virtual_cpus

--- a/internal/provider/log_export_config_resource.go
+++ b/internal/provider/log_export_config_resource.go
@@ -82,7 +82,6 @@ var logExportAttributes = map[string]schema.Attribute{
 				"redact": schema.BoolAttribute{
 					Optional:            true,
 					MarkdownDescription: "Governs whether this log group should aggregate redacted logs if unset.",
-					Computed:            true,
 				},
 			},
 		},


### PR DESCRIPTION
Currently, the "redact" field in the individual log groups is declared as a "computed" field. When a field is marked as "computed", user removing the field/commenting it out is sometimes not recognised as a "diff" in terraform state. This makes it look like the "redact" field is not working

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s) -- Tested manually on staging
- [ ] ~Acceptance test(s)~ No new test was added
- [ ] ~Example(s)~ No change in usage. This is just a bugfix.

---

### Manual test


Applied this configuration of the `log_exporter`
<img width="1916" alt="Screenshot 2023-11-30 at 4 26 00 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/11977524/06be32f3-93cf-4555-a712-111f75c07055">

#### Before

Does not show a diff when `redact` is commented out in the second log group
<img width="1916" alt="Screenshot 2023-11-30 at 4 29 36 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/11977524/81f04300-a8a3-4571-95a8-a7667af4820d">

#### After the change

Shows the expected diff
<img width="1916" alt="Screenshot 2023-11-30 at 4 31 03 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/11977524/d8c636d9-0a5a-4ac4-b449-0c1edb6e83a1">



