### PR TITLE
minor textual changes to README and dedicated example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Update docs for allowlist resource to clear up with cidr_mask is
+
+- Realign variables used in the cockroach_dedicated_cluster with the README
+
+- Removed mention of Limited Access for Azure clusters in README
+
+- Added some example values for clarity in README
+
 ## [1.7.5] - 2024-06-06
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
     cloud_provider = "<cloud provider>"
     cloud_provider_regions = ["<cloud provider region>"]
     cluster_node_count = <number of nodes>
+    num_virtual_cpus = <number of VCPUs per node>
     storage_gib = <storage in GiB>
-    machine_type = "<cloud provider machine type>"
     allow_list_name = "<allow list name>"
     cidr_ip = "<allow list CIDR IP>"
-    cidr_mask = <allow list CIDR prefix>
+    cidr_prefix_length = <allow list CIDR prefix length>
     os = "<OS name>"
     ~~~
 
@@ -130,14 +130,14 @@ Before you use `terraform-provider-cockroach` you must [install Terraform](https
         - `<database name>` is the name that will be used for the database created within the cluster. This database is in addition to defaultdb which is created by default.  
         - `<SQL user name>` is the name of the SQL user you want to create.  
         - `<SQL user password>` is the password for the SQL user you want to create.  
-        - `<cloud provider>` is the cloud infrastructure provider. Possible values are `GCP` or `AWS` or `AZURE` (limited access).  
+        - `<cloud provider>` is the cloud infrastructure provider. Possible values are `GCP` or `AWS` or `AZURE`.  
         - `<cloud provider region>` is the region code or codes for the cloud infrastructure provider. For multi-region clusters, separate each region with a comma.  
         - `<number of nodes>` is the number of nodes in each region. Cockroach Labs recommends at least 3 nodes per region, and the same number of nodes in each region for multi-region clusters.  
+        - `<number of VCPUs per node>` is the number of virtual CPUS assigned to each node.  This number will dictate which machine type is used for your cluster nodes. Recommendations for choosing this value can be found [here](https://www.cockroachlabs.com/docs/cockroachcloud/create-your-cluster#step-5-configure-cluster-capacity).  
         - `<storage in GiB>` is the amount of storage specified in GiB.  
-        - `<cloud provider machine type>` is the machine type for the cloud infrastructure provider.  
-        - `<allow list name>` is the name for the IP allow list. Use a descriptive name to identify the IP allow list.  
-        - `<allow list CIDR IP>` is the Classless Inter-Domain Routing (CIDR) IP address base.  
-        - `<allow list CIDR prefix>` is the CIDR prefix. This should be a number from 0 to 32. Use 32 to only allow the single IP Address passed in cidr_ip.  
+        - `<allow list name>` is the name for the IP allow list. Use a descriptive name to identify the IP allow list. (i.e. "allow all" or "home network")  
+        - `<allow list CIDR IP>` is the Classless Inter-Domain Routing (CIDR) IP address base. (i.e. 123.123.123.123)  
+        - `<allow list CIDR prefix length>` is the CIDR prefix length. This should be a number from 0 to 32. Use 32 to only allow the single IP Address passed in cidr_ip.  
         - `<OS name>` is the name of the OS that will be used to connect from for connection string output. Possible values are ('WINDOWS', 'MAC', and 'LINUX').  
 
 1. Initialize the provider.

--- a/docs/resources/allow_list.md
+++ b/docs/resources/allow_list.md
@@ -29,7 +29,7 @@ resource "cockroach_allow_list" "vpn" {
 ### Required
 
 - `cidr_ip` (String) IP address component of the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) range for this entry.
-- `cidr_mask` (Number) Map component of the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) range for this entry.
+- `cidr_mask` (Number) The [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation prefix length. A number ranging from 0 to 32 indicating the size of the network. Use 32 to allow a single IP address.
 - `cluster_id` (String)
 - `sql` (Boolean) Set to 'true' to allow SQL connections from this CIDR range.
 - `ui` (Boolean) Set to 'true' to allow access to the management console from this CIDR range.

--- a/examples/workflows/cockroach_dedicated_cluster/main.tf
+++ b/examples/workflows/cockroach_dedicated_cluster/main.tf
@@ -73,7 +73,7 @@ variable "cidr_ip" {
   default  = "0.0.0.0"
 }
 
-variable "cidr_mask" {
+variable "cidr_prefix_length" {
   type     = number
   nullable = false
   default  = 0
@@ -112,7 +112,7 @@ data "cockroach_cluster_cert" "example" {
 resource "cockroach_allow_list" "example" {
   name       = var.allow_list_name
   cidr_ip    = var.cidr_ip
-  cidr_mask  = var.cidr_mask
+  cidr_mask  = var.cidr_prefix_length
   ui         = true
   sql        = true
   cluster_id = cockroach_cluster.example.id
@@ -140,7 +140,9 @@ data "cockroach_connection_string" "example" {
 
   # Caution: Including the `password` field will result in
   # the password showing up in plain text in the
-  # connection string output!
+  # connection string output! We recommend following terraform best practices
+  # for securing sensitive variables.
+  # https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables
   #
   # password = cockroach_sql_user.example.password
 

--- a/internal/provider/allowlist_resource.go
+++ b/internal/provider/allowlist_resource.go
@@ -70,7 +70,7 @@ func (r *allowListResource) Schema(
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.RequiresReplace(),
 				},
-				MarkdownDescription: "Map component of the [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) range for this entry.",
+				MarkdownDescription: "The [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation) notation prefix length. A number ranging from 0 to 32 indicating the size of the network. Use 32 to allow a single IP address.",
 			},
 			"ui": schema.BoolAttribute{
 				Required:    true,


### PR DESCRIPTION
Including:
* sync variables mentioned in README with actual example
* add example values for allow list name and CIDR IP
* remove limited access denotion for Azure clusters
* add link to terraform sensitive values recommendations in example comment.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
