### PR TITLE
fix error when primary attribute is specified in multiple regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a nil pointer exception which could occur while retrying a certain
   class of api failures.
+- Fixed error when the primary attribute was specified in multiple regions,
+  even when false in all but one region.
 
 ## [1.3.0] - 2023-09-14
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -295,10 +295,6 @@ func (r *clusterResource) ConfigValidators(_ context.Context) []resource.ConfigV
 			path.MatchRoot("serverless").AtName("usage_limits").AtName("storage_mib_limit"),
 			path.MatchRoot("serverless").AtName("usage_limits").AtName("provisioned_capacity"),
 		),
-		resourcevalidator.Conflicting(
-			path.MatchRoot("regions").AtAnyListIndex().AtName("primary"),
-			path.MatchRoot("dedicated"),
-		),
 	}
 }
 
@@ -361,6 +357,10 @@ func (r *clusterResource) Create(
 			regionNodes := make(map[string]int32, len(plan.Regions))
 			for _, region := range plan.Regions {
 				regionNodes[region.Name.ValueString()] = int32(region.NodeCount.ValueInt64())
+				if IsKnown(region.Primary) {
+					resp.Diagnostics.AddError("Invalid Attribute Combination",
+						"Dedicated clusters do not support the primary attribute on regions.")
+				}
 			}
 			dedicated.RegionNodes = regionNodes
 		}

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -98,6 +98,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 		os.Setenv(CockroachAPIKey, "fake")
 	}
 
+	boolPtr := func(val bool) *bool { return &val }
 	int64Ptr := func(val int64) *int64 { return &val }
 	clusterName := fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2))
 
@@ -179,8 +180,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 				},
 			},
 		}
-		trueVal := true
-		cluster.Regions[primaryIndex].Primary = &trueVal
+		cluster.Regions[primaryIndex].Primary = boolPtr(true)
 		return cluster
 	}
 
@@ -384,6 +384,17 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 							}]
 						}`,
 					ExpectError: regexp.MustCompile("Invalid Attribute Combination"),
+				}
+			},
+		},
+		{
+			name: "use serverless primary region on dedicated cluster",
+			createStep: func() resource.TestStep {
+				config := getTestDedicatedClusterResourceConfig(clusterName, latestClusterMajorVersion, false, 4)
+				config = strings.Replace(config, "node_count: 1", "primary: true", -1)
+				return resource.TestStep{
+					Config:      config,
+					ExpectError: regexp.MustCompile("Dedicated clusters do not support the primary attribute on regions."),
 				}
 			},
 		},
@@ -592,6 +603,7 @@ func provisionedMultiRegionClusterWithLimit(clusterName string) resource.TestSte
 					},
 					{
 						name = "us-west2"
+						primary = false
 					},
 				]
 			}


### PR DESCRIPTION
Previously, the TF provider raised an error when the primary attribute was specified in multiple regions, e.g.:

  regions = [
    {
      name    = "eu-west-1"
      primary = true
    },
    {
      name    = "eu-west2"
      primary = false
    },
    {
      name    = "ap-south-1"
      primary = false
    },
  ]

This PR fixes that by adding some custom validation logic rather than using the built-in config validators.

Fixes: CC-27160

**Commit checklist**
- [X] Changelog
- [X] Doc gen (`make generate`)
- [X] Integration test(s)
- [X] Acceptance test(s)
- [X] Example(s)
