### PR TITLE
enable request logging when debug is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed example files to the correct name so they are automatically included
   in the docs.
 
+## Added
+
+- Allow the logging of requests to the cloud SDK by setting either TF_LOG or
+  TF_LOG_PROVIDER envvars to either DEBUG or TRACE.
+
 ## [1.3.1] - 2023-12-01
 
 ### Fixed

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -89,6 +89,16 @@ func (p *provider) Configure(
 	}
 	cfg.UserAgent = UserAgent
 
+	logLevel := os.Getenv("TF_LOG")
+	if logLevel == "DEBUG" || logLevel == "TRACE" {
+		cfg.Debug = true
+	} else {
+		logLevel = os.Getenv("TF_LOG_PROVIDER")
+		if logLevel == "DEBUG" || logLevel == "TRACE" {
+			cfg.Debug = true
+		}
+	}
+
 	// retryablehttp gives us automatic retries with exponential backoff.
 	httpClient := retryablehttp.NewClient()
 	// The TF framework will pick up the default global logger.


### PR DESCRIPTION
Previously, enabling debug for the tf provider did not log out requests. The cloud sdk already supported a debug mode. We now enable this via configuration if one of the terraform debug env vars (TF_LOG_PROVIDER or TF_LOG) are set to either "DEBUG" or "TRACE".

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
