### PR TITLE
Use new private endpoint connections API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Notes
+
+- The `private_endpoint_connection` resource can now be used to create private
+  endpoint connections on every supported cloud-provider and cluster type,
+  except Serverless clusters on Azure as that configuration is not yet
+  available.
+
 ### Fixed
 
 - Renamed example files to the correct name so they are automatically included

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -3,12 +3,12 @@
 page_title: "cockroach_private_endpoint_connection Resource - terraform-provider-cockroach"
 subcategory: ""
 description: |-
-  AWS PrivateLink Endpoint Connection.
+  Private Endpoint Connection.
 ---
 
 # cockroach_private_endpoint_connection (Resource)
 
-AWS PrivateLink Endpoint Connection.
+Private Endpoint Connection.
 
 
 
@@ -18,13 +18,13 @@ AWS PrivateLink Endpoint Connection.
 ### Required
 
 - `cluster_id` (String)
-- `endpoint_id` (String) Client side ID of the PrivateLink connection.
+- `endpoint_id` (String) Client side ID of the Private Endpoint Connection.
 
 ### Read-Only
 
 - `cloud_provider` (String) Cloud provider associated with this connection.
 - `id` (String) Used with `terraform import`. Format is "<cluster ID>:<endpoint ID>".
 - `region_name` (String) Cloud provider region code associated with this connection.
-- `service_id` (String) Server side ID of the PrivateLink connection.
+- `service_id` (String) Server side ID of the Private Endpoint Connection.
 
 

--- a/examples/resources/cockroach_aws_private_endpoint_connection/resource.tf
+++ b/examples/resources/cockroach_aws_private_endpoint_connection/resource.tf
@@ -1,10 +1,9 @@
 variable "cluster_id" {
-  type = string
+  type        = string
+  description = "the id for the CockroachDB Cloud cluster"
 }
 
 resource "cockroach_private_endpoint_connection" "cockroach" {
   cluster_id     = var.cluster_id
-  endpoint_id    = "endpoint id assigned by consumer AWS"
-  cloud_provider = "AWS"
-  region_name    = "AWS region in which the endpoint was created"
+  endpoint_id    = "the endpoint id assigned by cloud provider to the client-side of the connection"
 }


### PR DESCRIPTION
    Previously, the private_endpoint_connection resource only supported AWS
    private link connections. This commit updates the provider code to use
    the new CC API Private Endpoint Connections methods. These cloud-neutral
    methods will work for all cloud providers and cluster types, except
    Serverless clusters on Azure as that configuration is not yet
    supported.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
