### PR TITLE
private endpoint services: support all clouds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2024-03-15
+
 ### Changed
+
+- The `private_endpoint_connection` resource can now be used to create private
+  endpoint connections on every supported cloud-provider and cluster type,
+  except Serverless clusters on Azure as that configuration is not yet
+  available.
 
 - Migrated the testing framework to
   https://github.com/hashicorp/terraform-plugin-testing.
@@ -21,17 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `private_endpoint_services` resource could be created without populating
   the state file with the service information.
-
-## [1.3.2] - 2024-03-13
-
-### Changed
-
-- The `private_endpoint_connection` resource can now be used to create private
-  endpoint connections on every supported cloud-provider and cluster type,
-  except Serverless clusters on Azure as that configuration is not yet
-  available.
-
-### Fixed
 
 - Renamed example files to the correct name so they are automatically included
   in the docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated the testing framework to
   https://github.com/hashicorp/terraform-plugin-testing.
 
+- The `private_endpoint_services` resource can now be used to create private
+  endpoint services on every supported cloud provider.
+
+- Use CockroachDB v23.1 and v23.2 in tests.
+
+### Fixed
+
+- The `private_endpoint_services` resource could be created without populating
+  the state file with the service information.
+
 ## [1.3.2] - 2024-03-13
 
 ### Changed

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -3,12 +3,12 @@
 page_title: "cockroach_private_endpoint_services Resource - terraform-provider-cockroach"
 subcategory: ""
 description: |-
-  PrivateEndpointServices contains services that allow for VPC communication, either via PrivateLink (AWS) or Peering (GCP).
+  PrivateEndpointServices contains services that allow for for private connectivity to the CockroachDB Cloud cluster.
 ---
 
 # cockroach_private_endpoint_services (Resource)
 
-PrivateEndpointServices contains services that allow for VPC communication, either via PrivateLink (AWS) or Peering (GCP).
+PrivateEndpointServices contains services that allow for for private connectivity to the CockroachDB Cloud cluster.
 
 ## Example Usage
 
@@ -39,8 +39,11 @@ resource "cockroach_private_endpoint_services" "cockroach" {
 
 Read-Only:
 
-- `aws` (Attributes) (see [below for nested schema](#nestedatt--services--aws))
+- `availability_zone_ids` (List of String) AZ IDs users should create their VPCs in to minimize their cost.
+- `aws` (Attributes, Deprecated) (see [below for nested schema](#nestedatt--services--aws))
 - `cloud_provider` (String) Cloud provider associated with this service.
+- `endpoint_service_id` (String) Server side ID of the private endpoint connection.
+- `name` (String) Name of the endpoint service.
 - `region_name` (String) Cloud provider region code associated with this service.
 - `status` (String) Operation status of the service.
 

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -40,10 +40,10 @@ const (
 	// The patch versions are just for mocks. They don't need to be the actual
 	// latest available patch versions; they just need to resolve to the correct
 	// major versions.
-	minSupportedClusterMajorVersion = "v22.2"
-	minSupportedClusterPatchVersion = "v22.2.0"
-	latestClusterMajorVersion       = "v23.1"
-	latestClusterPatchVersion       = "v23.1.0"
+	minSupportedClusterMajorVersion = "v23.1"
+	minSupportedClusterPatchVersion = "v23.1.0"
+	latestClusterMajorVersion       = "v23.2"
+	latestClusterPatchVersion       = "v23.2.0"
 )
 
 // TestAccClusterResource attempts to create, check, update, and destroy

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -107,10 +107,13 @@ type PrivateLinkServiceAWSDetail struct {
 }
 
 type PrivateEndpointService struct {
-	RegionName    types.String                `tfsdk:"region_name"`
-	CloudProvider types.String                `tfsdk:"cloud_provider"`
-	Status        types.String                `tfsdk:"status"`
-	Aws           PrivateLinkServiceAWSDetail `tfsdk:"aws"`
+	RegionName          types.String                `tfsdk:"region_name"`
+	CloudProvider       types.String                `tfsdk:"cloud_provider"`
+	Status              types.String                `tfsdk:"status"`
+	Name                types.String                `tfsdk:"name"`
+	EndpointServiceId   types.String                `tfsdk:"endpoint_service_id"`
+	AvailabilityZoneIds []types.String              `tfsdk:"availability_zone_ids"`
+	Aws                 PrivateLinkServiceAWSDetail `tfsdk:"aws"`
 }
 
 type PrivateEndpointServices struct {


### PR DESCRIPTION
Previously, the private_endpoint_services resource only supported the creation of AWS private endpoint services. This commit removes this restriction, now all clouds are supported. Additionally this commit fixes a bug that caused the private_endpoint_service resource to be created without the resource state being loaded into the state file. Lastly, this commit bumps the CRDB version used for testing.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
