### PR TITLE
Update changelog for 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2024-03-22
+
 ### Added
 
 - The


### PR DESCRIPTION
Updated the changelog for the 1.4.0 release. 

I ran the full test suite against a staging org.  The tests that didn't pass all looked to be because of various feature flags that weren't flipped on my org.  The tagging process will run the tests again.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
