### PR TITLE
ensure all test cluster names have tftest prefix

### DIFF
--- a/internal/provider/allowlist_resource_test.go
+++ b/internal/provider/allowlist_resource_test.go
@@ -37,7 +37,7 @@ import (
 // isn't set.
 func TestAccDedicatedAllowlistEntryResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-networking-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-networking-%s", tfTestPrefix, GenerateRandomString(2))
 	entryName := "default-allow-list"
 	entry := client.AllowlistEntry{
 		Name:     &entryName,
@@ -62,7 +62,7 @@ func TestAccDedicatedAllowlistEntryResource(t *testing.T) {
 // isn't set.
 func TestAccServerlessAllowlistEntryResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-networking-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-networking-%s", tfTestPrefix, GenerateRandomString(2))
 	entryName := "default-allow-list"
 	entry := client.AllowlistEntry{
 		Name:     &entryName,
@@ -85,7 +85,7 @@ func TestAccServerlessAllowlistEntryResource(t *testing.T) {
 // TestIntegrationAllowlistEntryResource attempts to create, check, and
 // destroy a cluster and allowlist entry, but uses a mocked API service.
 func TestIntegrationAllowlistEntryResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-networking-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-networking-%s", tfTestPrefix, GenerateRandomString(2))
 	clusterID := uuid.Nil.String()
 	name := "default-allow-list"
 	// Return another entry in the List call to make sure we're selecting

--- a/internal/provider/client_ca_cert_resource_test.go
+++ b/internal/provider/client_ca_cert_resource_test.go
@@ -34,7 +34,7 @@ import (
 // a real cluster and client CA certs. It will be skipped if TF_ACC isn't set.
 func TestAccClientCACertResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-clcacert-%s", GenerateRandomString(3))
+	clusterName := fmt.Sprintf("%s-clcacert-%s", tfTestPrefix, GenerateRandomString(3))
 
 	// test cert with CN=test1
 	cert1 := "-----BEGIN CERTIFICATE-----\nMIIDgTCCAmigAwIBAgIBADANBgkqhkiG9w0BAQ0FADBaMQswCQYDVQQGEwJ1czEL\nMAkGA1UECAwCV0ExDjAMBgNVBAoMBXRlc3QxMQ4wDAYDVQQDDAV0ZXN0MTEOMAwG\nA1UEBwwFdGVzdDExDjAMBgNVBAsMBXRlc3QxMB4XDTIzMDMyMTE5MDczN1oXDTI2\nMDMyMDE5MDczN1owWjELMAkGA1UEBhMCdXMxCzAJBgNVBAgMAldBMQ4wDAYDVQQK\nDAV0ZXN0MTEOMAwGA1UEAwwFdGVzdDExDjAMBgNVBAcMBXRlc3QxMQ4wDAYDVQQL\nDAV0ZXN0MTCCASMwDQYJKoZIhvcNAQEBBQADggEQADCCAQsCggECAL8DDMgY6Vck\nL1VfzXRXsGVYIdq/NQdVLUAUB/7WCd6/lVGvCMn/iR1uYUSDhTvW2CB4NqbFBE9Y\nBwS5OZMqficezfR8xxRDsIIqjSlpWzE0j7uROyCFxXpt9PyIgTVX2Hj8xov8Y7aT\nS5yddCURxjTC5/Fllwizn7PcJAqOcpzlqddHUXvcGKrEljyAf6fbpcCug4tR3Fq3\ngf5rfwm1YR8w+GyFRiWy3B27oIftEEZ4GaN/J9+d5MZGS00PemilcQ3HyD20k7VU\nbTylkYoDbTrt3ivK1SllkmOHtQ8eBZCF3S9kpctnF9ohy6k2F16wdLQ/XcGhMG5d\nJ9eRWAXfy2EpAgMBAAGjUDBOMB0GA1UdDgQWBBR+mcFGBlCHOQe3H49JSdZMrqqS\nnDAfBgNVHSMEGDAWgBR+mcFGBlCHOQe3H49JSdZMrqqSnDAMBgNVHRMEBTADAQH/\nMA0GCSqGSIb3DQEBDQUAA4IBAgAZwBCWrvwxTnJ/3LtE8yG5tfhjoXZg3q19ZrNh\nza0fElnvxONgNtLHjjNCWaf3er9EGW/Ge2NWuMGHjTwRwG9VzFETcnDrZVLf6uF7\noriyzsno0Ob5VZkgeyFw23l/nEzGYtVM549Fz65trzyASOtqi1AH95xTd6fh3goq\nd9ivSkP1FzGr4fwz8k9LQhE8YASgH6mZ5dO3ZNQjYzGsU7T5MIK/TYoyS4DDKQMM\nGbhUuJXSoTsHrs9Jma6mGoBQaxJet6RfTk1+fDnCl9OdlS66Ez3V7KsLJ4Lzzi8S\nJh5teJQymchzWt4Imn7VSHqedIF9psNaJ/ucHVaJAzkKBJGTzA==\n-----END CERTIFICATE-----"
@@ -45,7 +45,7 @@ func TestAccClientCACertResource(t *testing.T) {
 }
 
 func TestIntegrationClientCACertResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-clcacert-%s", GenerateRandomString(3))
+	clusterName := fmt.Sprintf("%s-clcacert-%s", tfTestPrefix, GenerateRandomString(3))
 	clusterId := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/cluster_cert_data_source_test.go
+++ b/internal/provider/cluster_cert_data_source_test.go
@@ -35,13 +35,13 @@ import (
 // It will be skipped if TF_ACC isn't set.
 func TestAccClusterCertDataSource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-cert-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-cert-%s", tfTestPrefix, GenerateRandomString(4))
 
 	testClusterCertDataSource(t, clusterName, false)
 }
 
 func TestIntegrationClusterCertDataSource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-cert-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-cert-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterId := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -50,7 +50,7 @@ const (
 // a real cluster. It will be skipped if TF_ACC isn't set.
 func TestAccServerlessClusterResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-serverless-%s", tfTestPrefix, GenerateRandomString(2))
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               false,
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -68,7 +68,7 @@ func TestAccServerlessClusterResource(t *testing.T) {
 // a real multi-region serverless cluster. It will be skipped if TF_ACC isn't set.
 func TestAccMultiRegionServerlessClusterResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-multi-region-serverless-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-multi-region-serverless-%s", tfTestPrefix, GenerateRandomString(2))
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               false,
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -91,7 +91,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 	true_val := true
 	initialCluster := client.Cluster{
 		Id:               uuid.Nil.String(),
-		Name:             fmt.Sprintf("tftest-serverless-%s", GenerateRandomString(2)),
+		Name:             fmt.Sprintf("%s-serverless-%s", tfTestPrefix, GenerateRandomString(2)),
 		CockroachVersion: latestClusterPatchVersion,
 		Plan:             "SERVERLESS",
 		CloudProvider:    "GCP",
@@ -568,12 +568,12 @@ func multiRegionServerlessClusterResourceRegionUpdate(clusterName string) resour
 
 func TestAccDedicatedClusterResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-dedicated-%s", GenerateRandomString(3))
+	clusterName := fmt.Sprintf("%s-dedicated-%s", tfTestPrefix, GenerateRandomString(3))
 	testDedicatedClusterResource(t, clusterName, false)
 }
 
 func TestIntegrationDedicatedClusterResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-dedicated-%s", GenerateRandomString(3))
+	clusterName := fmt.Sprintf("%s-dedicated-%s", tfTestPrefix, GenerateRandomString(3))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/cmek_resource_test.go
+++ b/internal/provider/cmek_resource_test.go
@@ -35,14 +35,14 @@ func TestAccCMEKResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-cmek-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-cmek-%s", tfTestPrefix, GenerateRandomString(4))
 	testCMEKResource(t, clusterName, false)
 }
 
 // TestIntegrationCMEKResource attempts to create, check, and destroy
 // a cluster, but uses a mocked API service.
 func TestIntegrationCMEKResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-cmek-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-cmek-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/connection_string_data_source_test.go
+++ b/internal/provider/connection_string_data_source_test.go
@@ -35,13 +35,13 @@ import (
 // connection string. It will be skipped if TF_ACC isn't set.
 func TestAccConnectionStringDataSource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-connect-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-connect-%s", tfTestPrefix, GenerateRandomString(4))
 
 	testConnectionStringDataSource(t, clusterName, false)
 }
 
 func TestIntegrationConnectionStringDataSource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-connect-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-connect-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterId := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -36,7 +36,7 @@ import (
 // a real database and its cluster. It will be skipped if TF_ACC isn't set.
 func TestAccDatabaseResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-database-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-database-%s", tfTestPrefix, GenerateRandomString(4))
 	databaseName := "cockroach-database"
 	newDatabaseName := "cockroach-database-updated"
 
@@ -46,7 +46,7 @@ func TestAccDatabaseResource(t *testing.T) {
 // TestIntegrationDatabaseResource attempts to create, check, update, and
 // destroy a database and its cluster, but uses a mocked API service.
 func TestIntegrationDatabaseResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-database-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-database-%s", tfTestPrefix, GenerateRandomString(4))
 	databaseName := "test-database"
 	newDatabaseName := "test-database-updated"
 	clusterID := uuid.Nil.String()

--- a/internal/provider/folder_data_source_test.go
+++ b/internal/provider/folder_data_source_test.go
@@ -34,8 +34,8 @@ import (
 // It will be skipped if TF_ACC isn't set.
 func TestAccFolderDataSource(t *testing.T) {
 	t.Parallel()
-	parentName := fmt.Sprintf("tftest-parent-%s", GenerateRandomString(4))
-	childName := fmt.Sprintf("tftest-child-%s", GenerateRandomString(4))
+	parentName := fmt.Sprintf("%s-parent-%s", tfTestPrefix, GenerateRandomString(4))
+	childName := fmt.Sprintf("%s-child-%s", tfTestPrefix, GenerateRandomString(4))
 
 	testFolderDataSource(t, parentName, childName, false)
 }
@@ -50,8 +50,8 @@ func TestIntegrationFolderDataSource(t *testing.T) {
 		os.Setenv(CockroachAPIKey, "fake")
 	}
 
-	parentName := fmt.Sprintf("tftest-parent-%s", GenerateRandomString(4))
-	childName := fmt.Sprintf("tftest-child-%s", GenerateRandomString(4))
+	parentName := fmt.Sprintf("%s-parent-%s", tfTestPrefix, GenerateRandomString(4))
+	childName := fmt.Sprintf("%s-child-%s", tfTestPrefix, GenerateRandomString(4))
 
 	rootID := "root"
 	parentID := uuid.Must(uuid.Parse("00000000-0000-0000-0000-000000000001")).String()

--- a/internal/provider/folder_resource_test.go
+++ b/internal/provider/folder_resource_test.go
@@ -21,9 +21,9 @@ import (
 func TestAccFolderResource(t *testing.T) {
 	t.Parallel()
 	var (
-		folderName       = fmt.Sprintf("tftest-folder-%s", GenerateRandomString(4))
-		newFolderName    = fmt.Sprintf("tftest-folder-%s", GenerateRandomString(4))
-		parentFolderName = fmt.Sprintf("tftest-folder-%s", GenerateRandomString(4))
+		folderName       = fmt.Sprintf("%s-folder-%s", tfTestPrefix, GenerateRandomString(4))
+		newFolderName    = fmt.Sprintf("%s-folder-%s", tfTestPrefix, GenerateRandomString(4))
+		parentFolderName = fmt.Sprintf("%s-folder-%s", tfTestPrefix, GenerateRandomString(4))
 	)
 	testFolderResource(t, parentFolderName, folderName, newFolderName, false)
 }

--- a/internal/provider/log_export_config_resource_test.go
+++ b/internal/provider/log_export_config_resource_test.go
@@ -38,14 +38,14 @@ func TestAccLogExportConfigResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-logexp-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-logexp-%s", tfTestPrefix, GenerateRandomString(4))
 	testLogExportConfigResource(t, clusterName, false)
 }
 
 // TestIntegrationLogExportConfigResource attempts to create, check, and destroy
 // a cluster, but uses a mocked API service.
 func TestIntegrationLogExportConfigResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-logexp-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-logexp-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/maintenance_window_test.go
+++ b/internal/provider/maintenance_window_test.go
@@ -33,14 +33,14 @@ import (
 // real cluster. It will be skipped if TF_ACC isn't set.
 func TestAccMaintenanceWindowResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-mwin-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-mwin-%s", tfTestPrefix, GenerateRandomString(4))
 	testMaintenanceWindowResource(t, clusterName, false)
 }
 
 // TestIntegrationMaintenanceWindowResource attempts to create, check, and
 // destroy a cluster, but uses a mocked API service.
 func TestIntegrationMaintenanceWindowResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-mwin-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-mwin-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/metric_export_cloudwatch_config_resource_test.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource_test.go
@@ -38,14 +38,14 @@ func TestAccMetricExportCloudWatchConfigResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-cloudwatch-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-cloudwatch-%s", tfTestPrefix, GenerateRandomString(2))
 	testMetricExportCloudWatchConfigResource(t, clusterName, false)
 }
 
 // TestIntegrationMetricExportCloudWatchConfigResource attempts to create, check,
 // and destroy a cluster, but uses a mocked API service.
 func TestIntegrationMetricExportCloudWatchConfigResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-cloudwatch-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-cloudwatch-%s", tfTestPrefix, GenerateRandomString(2))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/metric_export_datadog_config_resource_test.go
+++ b/internal/provider/metric_export_datadog_config_resource_test.go
@@ -38,14 +38,14 @@ func TestAccMetricExportDatadogConfigResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-datadog-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-datadog-%s", tfTestPrefix, GenerateRandomString(4))
 	testMetricExportDatadogConfigResource(t, clusterName, false)
 }
 
 // TestIntegrationMetricExportDatadogConfigResource attempts to create, check,
 // and destroy a cluster, but uses a mocked API service.
 func TestIntegrationMetricExportDatadogConfigResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-datadog-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-datadog-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/private_endpoint_connection_resource_test.go
+++ b/internal/provider/private_endpoint_connection_resource_test.go
@@ -33,7 +33,7 @@ func TestAccDedicatedPrivateEndpointConnectionResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("aws-connection-%s", GenerateRandomString(5))
+	clusterName := fmt.Sprintf("%s-aws-conn-%s", tfTestPrefix, GenerateRandomString(3))
 	testPrivateEndpointConnectionResource(t, clusterName, false /* useMock */, false /* isServerless */)
 }
 
@@ -41,12 +41,12 @@ func TestAccServerlessPrivateEndpointConnectionResource(t *testing.T) {
 	t.Skip("Skipping until we can either integrate the AWS provider " +
 		"or import a permanent test fixture.")
 	t.Parallel()
-	clusterName := fmt.Sprintf("aws-connection-%s", GenerateRandomString(5))
+	clusterName := fmt.Sprintf("%s-aws-conn-%s", tfTestPrefix, GenerateRandomString(3))
 	testPrivateEndpointConnectionResource(t, clusterName, false /* useMock */, true /* isServerless */)
 }
 
 func TestIntegrationPrivateEndpointConnectionResource(t *testing.T) {
-	clusterName := fmt.Sprintf("private-connection-%s", GenerateRandomString(5))
+	clusterName := fmt.Sprintf("%s-priv-conn-%s", tfTestPrefix, GenerateRandomString(2))
 	clusterID := uuid.Nil.String()
 	endpointID := "endpoint-id"
 	if os.Getenv(CockroachAPIKey) == "" {

--- a/internal/provider/private_endpoint_services_resource_test.go
+++ b/internal/provider/private_endpoint_services_resource_test.go
@@ -35,7 +35,7 @@ import (
 // skipped if TF_ACC isn't set.
 func TestAccDedicatedPrivateEndpointServicesResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-endpt-svc-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-endpt-svc-%s", tfTestPrefix, GenerateRandomString(2))
 	testPrivateEndpointServicesResource(t, clusterName, false /* useMock */, false /* isServerless */)
 }
 
@@ -44,14 +44,14 @@ func TestAccDedicatedPrivateEndpointServicesResource(t *testing.T) {
 // skipped if TF_ACC isn't set.
 func TestAccServerlessPrivateEndpointServicesResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-endpt-svc-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-endpt-svc-%s", tfTestPrefix, GenerateRandomString(2))
 	testPrivateEndpointServicesResource(t, clusterName, false /* useMock */, true /* isServerless */)
 }
 
 // TestIntegrationAllowlistEntryResource attempts to create, check, and destroy
 // a cluster and endpoint services, but uses a mocked API service.
 func TestIntegrationPrivateEndpointServicesResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-endpt-svc-%s", GenerateRandomString(2))
+	clusterName := fmt.Sprintf("%s-endpt-svc-%s", tfTestPrefix, GenerateRandomString(2))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")

--- a/internal/provider/private_endpoint_trusted_owner_resource_test.go
+++ b/internal/provider/private_endpoint_trusted_owner_resource_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestAccDedicatedPrivateEndpointTrustedOwnerResource(t *testing.T) {
-	clusterName := fmt.Sprintf("trusted-owner-%s", GenerateRandomString(5))
+	clusterName := fmt.Sprintf("%s-trstd-own-%s", tfTestPrefix, GenerateRandomString(2))
 	testPrivateEndpointTrustedOwnerResource(t, clusterName, false /* useMock */)
 }
 
@@ -52,7 +52,7 @@ func TestIntegrationPrivateEndpointTrustedOwnerResource(t *testing.T) {
 
 	// States in the server.
 	cluster := client.Cluster{
-		Name:          fmt.Sprintf("trusted-owner-%s", GenerateRandomString(5)),
+		Name:          fmt.Sprintf("%s-trstd-own-%s", tfTestPrefix, GenerateRandomString(2)),
 		Id:            clusterID,
 		CloudProvider: "AWS",
 		Config: client.ClusterConfig{

--- a/internal/provider/sql_user_resource_test.go
+++ b/internal/provider/sql_user_resource_test.go
@@ -38,7 +38,7 @@ const testPassword = "random-password"
 // a real cluster and SQL user. It will be skipped if TF_ACC isn't set.
 func TestAccSqlUserResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-sql-user-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-sql-user-%s", tfTestPrefix, GenerateRandomString(4))
 	sqlUserNameWithPass := "cockroach-user"
 	sqlUserNameNoPass := "cockroach-user-nopass"
 
@@ -48,7 +48,7 @@ func TestAccSqlUserResource(t *testing.T) {
 // TestIntegrationSqlUserResource attempts to create, check, and destroy
 // a cluster and SQL user, but uses a mocked API service.
 func TestIntegrationSqlUserResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-sql-user-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-sql-user-%s", tfTestPrefix, GenerateRandomString(4))
 	sqlUserNameWithPass := "cockroach-user"
 	sqlUserNameNoPass := "cockroach-user-nopass"
 	sqlPassword := "cockroach@123456"

--- a/internal/provider/user_role_grant_resource_test.go
+++ b/internal/provider/user_role_grant_resource_test.go
@@ -38,7 +38,7 @@ import (
 // real role grant for a user. It will be skipped if TF_ACC isn't set.
 func TestAccRoleGrantResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-rg-resource-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-rg-resource-%s", tfTestPrefix, GenerateRandomString(4))
 
 	// Skip the org test for the Acceptance Test because the test relies on the
 	// user having access to set an org level role. In order to avoid adding

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// tfTestPrefix is the test prefix to use when creating resources in acceptance
+// tests.  This makes them easier to find when resources are left dangling after
+// failed cleanup.
+const tfTestPrefix = "tftest"
+
 func addConfigureProviderErr(diagnostics *diag.Diagnostics) {
 	diagnostics.AddError(
 		"Provider not configured",

--- a/internal/provider/version_deferral_test.go
+++ b/internal/provider/version_deferral_test.go
@@ -30,14 +30,14 @@ import (
 // real cluster. It will be skipped if TF_ACC isn't set.
 func TestAccVersionDeferralResource(t *testing.T) {
 	t.Parallel()
-	clusterName := fmt.Sprintf("tftest-version-deferral-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-version-deferral-%s", tfTestPrefix, GenerateRandomString(4))
 	testVersionDeferralResource(t, clusterName, false)
 }
 
 // TestIntegrationVersionDeferralResource attempts to create, check, and
 // destroy a cluster, but uses a mocked API service.
 func TestIntegrationVersionDeferralResource(t *testing.T) {
-	clusterName := fmt.Sprintf("tftest-deferral-%s", GenerateRandomString(4))
+	clusterName := fmt.Sprintf("%s-deferral-%s", tfTestPrefix, GenerateRandomString(4))
 	clusterID := uuid.Nil.String()
 	if os.Getenv(CockroachAPIKey) == "" {
 		os.Setenv(CockroachAPIKey, "fake")


### PR DESCRIPTION
Prefixing the cluster names with "tftest" makes them easier to find in case they are failed to be cleaned up. Most were already prefixed that way. This change updates the remaining few that were not.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
