### PR TITLE
Add docs check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,3 +63,26 @@ jobs:
 
       - name: Build terraform-provider
         run: make install
+
+  docs-check:
+    name: docs-generated-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Build docs
+        run: make generate
+
+      - name: Check changed files
+        id: changed-files
+        run: |
+          changed_files=$(git diff --name-only | xargs)
+          if [ "${#changed_files}" -gt "0" ]; then
+            echo "Unexpected changes found in the repo, did you remember to run \`make generate\`?" > $GITHUB_STEP_SUMMARY
+            echo "Changed files:" >> $GITHUB_STEP_SUMMARY
+            for file in ${changed_files}; do
+              echo "\`$file\`" >> $GITHUB_STEP_SUMMARY
+            done
+            exit 1
+          fi


### PR DESCRIPTION
Add a github workflow that runs make generate and fails if there are any changes.

example failure:

<img width="974" alt="Screenshot 2024-05-02 at 5 23 13 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/6658984/a4769b53-263e-40d9-8777-e241e41326eb">

<img width="692" alt="Screenshot 2024-05-02 at 5 23 37 PM" src="https://github.com/cockroachdb/terraform-provider-cockroach/assets/6658984/37012ff5-79d1-4a13-a911-1e6556a5185f">
