### PR TITLE
fix allowlist_resource churn on empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2024-06-05
+
+## Fixed
+
+- Fixed apply churn when the optional name attribute in the allowlist resource was
+  not included.
+
 ## [1.7.0] - 2024-05-17
 
 ## Added

--- a/docs/resources/allow_list.md
+++ b/docs/resources/allow_list.md
@@ -36,7 +36,7 @@ resource "cockroach_allow_list" "vpn" {
 
 ### Optional
 
-- `name` (String) Name of this allowlist entry.
+- `name` (String) Name of this allowlist entry. If not set explicitly, this value does not sync with the server.
 
 ### Read-Only
 

--- a/internal/provider/allowlist_resource.go
+++ b/internal/provider/allowlist_resource.go
@@ -81,8 +81,9 @@ func (r *allowListResource) Schema(
 				Description: "Set to 'true' to allow SQL connections from this CIDR range.",
 			},
 			"name": schema.StringAttribute{
+				Computed:    true,
 				Optional:    true,
-				Description: "Name of this allowlist entry.",
+				Description: "Name of this allowlist entry. If not set explicitly, this value does not sync with the server.",
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -268,11 +269,12 @@ func (r *allowListResource) Update(
 	entryCIDRIp := plan.CidrIp.ValueString()
 	entryCIDRMask := int32(plan.CidrMask.ValueInt64())
 
-	name := plan.Name.ValueString()
 	updatedAllowList := client.AllowlistEntry1{
 		Ui:   plan.Ui.ValueBool(),
 		Sql:  plan.Sql.ValueBool(),
-		Name: &name,
+	}
+	if IsKnown(plan.Name) {
+		updatedAllowList.Name = ptr(plan.Name.ValueString())
 	}
 
 	traceAPICall("UpdateAllowlistEntry")

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -953,7 +953,3 @@ func TestClusterSchemaInSync(t *testing.T) {
 	dAttrs := dSchema.Schema.Attributes
 	CheckSchemaAttributesMatch(t, rAttrs, dAttrs)
 }
-
-func ptr[T any](in T) *T {
-	return &in
-}

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -169,6 +169,10 @@ func IsKnown[T Knowable](t T) bool {
 	return !t.IsUnknown() && !t.IsNull()
 }
 
+func ptr[T any](in T) *T {
+	return &in
+}
+
 // traceAPICall is a helper for debugging which api calls are happening when to
 // make it easier to determine for understanding what the provider framework is
 // doing and for determining which calls will need to be mocked in our tests.


### PR DESCRIPTION
Previously, allowlist.name attribute was not marked as computed so values from the server would not set the state in case it was unused. The server side default of "" would then conflict with a nil value in the state and show that it needed to be updated on every apply. We now mark the allowlist name as computed so that it can update the state when it is not set.  Additionally we stop sending the value on updates unless it explicitly set in the resource.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
