### PR TITLE
revert ghaction-import-gpg version back to 5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           cache: true
       -
         name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v5
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.7.3] - 2024-06-06
+## [1.7.4] - 2024-06-06
 
 ## Fixed
 
-- Updated goreleaser-action and ghaction-import-gpg actions.
-
-## [1.7.2] - 2024-06-05
-
-## Fixed
+- Updated goreleaser-action.
 
 - Updated cluster_resource tests for latest supported versions of the db.
 
 - Pinned version of go-releaser and updated arguments so it will work with version 2.
-
-## [1.7.1] - 2024-06-05
-
-## Fixed
 
 - Fixed apply churn when the optional name attribute in the allowlist resource was
   not included.


### PR DESCRIPTION
It seems like there is some approval process for using a later version of this and version 6 is not allowed.  For now we revert back to version 5 of this action.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
