### PR TITLE
revert go-releaser to v1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,10 @@ jobs:
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v3.1.0
         with:
-          args: release --clean
+          version: '~> v1'
+          args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.7.4] - 2024-06-06
+## [1.7.5] - 2024-06-06
 
 ## Fixed
 
-- Updated goreleaser-action.
-
-- Updated cluster_resource tests for latest supported versions of the db.
-
-- Pinned version of go-releaser and updated arguments so it will work with version 2.
+- Pinned version of go-releaser to version 1
 
 - Fixed apply churn when the optional name attribute in the allowlist resource was
   not included.


### PR DESCRIPTION
Pin the version of go-releaser to v1

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
