### PR TITLE
private_endpoint_services: fix backwards compat bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.6] - 2024-06-10
+
 ## Fixed
 
 - Update docs for allowlist resource to clear up with cidr_mask is
@@ -16,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed mention of Limited Access for Azure clusters in README
 
 - Added some example values for clarity in README
+
+- Fix bug when reading `cockroach_private_endpoint_services.#.aws.service_name`.
 
 ## [1.7.5] - 2024-06-06
 


### PR DESCRIPTION
Previously, when reading the `private_endpoint_services` resource for AWS the clusters, the '.aws' field remained unset, despite expectations otherwise. This commit fixes the bug to ensure that field remains set.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [x] Example(s)
