### PR TITLE
WIP: send resource type, hashed id back to ccapi

### DIFF
--- a/internal/provider/allowlist_resource.go
+++ b/internal/provider/allowlist_resource.go
@@ -109,10 +109,14 @@ func (r *allowListResource) Configure(
 	}
 }
 
+func (r *allowListResource) resourceType() string {
+	return providerResponseTypeName + "_allow_list"
+}
+
 func (r *allowListResource) Metadata(
-	_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
 ) {
-	resp.TypeName = req.ProviderTypeName + "_allow_list"
+	resp.TypeName = r.resourceType()
 }
 
 func (r *allowListResource) Create(
@@ -149,6 +153,7 @@ func (r *allowListResource) Create(
 	}
 
 	traceAPICall("AddAllowlistEntry")
+	ctx = contextWithResourceMetadata(ctx, r, entry.ID.ValueString())
 	_, _, err := r.provider.service.AddAllowlistEntry(ctx, entry.ClusterId.ValueString(), &allowList)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -256,10 +256,14 @@ func (r *clusterResource) Schema(
 	}
 }
 
+func (r *clusterResource) resourceType() string {
+	return providerResponseTypeName + "_cluster"
+}
+
 func (r *clusterResource) Metadata(
-	_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
 ) {
-	resp.TypeName = req.ProviderTypeName + "_cluster"
+	resp.TypeName = r.resourceType()
 }
 
 func (r *clusterResource) Configure(
@@ -476,6 +480,7 @@ func (r *clusterResource) Read(
 	}
 
 	traceAPICall("GetCluster")
+	ctx = contextWithResourceMetadata(ctx, r, clusterID)
 	clusterObj, httpResp, err := r.provider.service.GetCluster(ctx, clusterID)
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {

--- a/internal/provider/cmek_resource.go
+++ b/internal/provider/cmek_resource.go
@@ -110,6 +110,10 @@ type cmekResource struct {
 	provider *provider
 }
 
+func (r *cmekResource) resourceType() string {
+	return providerResponseTypeName + "_cmek"
+}
+
 func (r *cmekResource) Schema(
 	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
 ) {
@@ -120,9 +124,9 @@ func (r *cmekResource) Schema(
 }
 
 func (r *cmekResource) Metadata(
-	_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
+	_ context.Context, _ resource.MetadataRequest, resp *resource.MetadataResponse,
 ) {
-	resp.TypeName = req.ProviderTypeName + "_cmek"
+	resp.TypeName = r.resourceType()
 }
 
 func (r *cmekResource) Configure(
@@ -169,6 +173,7 @@ func (r *cmekResource) Create(
 	cmekSpec.SetRegionSpecs(regionSpecs)
 
 	traceAPICall("EnableCMEKSpec")
+	ctx = contextWithResourceMetadata(ctx, r, plan.ID.ValueString())
 	cmekObj, _, err := r.provider.service.EnableCMEKSpec(ctx, plan.ID.ValueString(), cmekSpec)
 	if err != nil {
 		resp.Diagnostics.AddError(

--- a/internal/provider/folder_resource.go
+++ b/internal/provider/folder_resource.go
@@ -51,10 +51,14 @@ func (r *folderResource) Schema(
 	}
 }
 
+func (r *folderResource) resourceType() string {
+	return providerResponseTypeName + "_folder"
+}
+
 func (r *folderResource) Metadata(
 	_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse,
 ) {
-	resp.TypeName = req.ProviderTypeName + "_folder"
+	resp.TypeName = r.resourceType()
 }
 
 func (r *folderResource) Configure(
@@ -87,6 +91,7 @@ func (r *folderResource) Create(
 
 	parentID := plan.ParentId.ValueString()
 	traceAPICall("CreateFolder")
+	ctx = contextWithResourceMetadata(ctx, r, "")
 	folderObj, _, err := r.provider.service.CreateFolder(ctx, &client.CreateFolderRequest{
 		Name:     plan.Name.ValueString(),
 		ParentId: &parentID,
@@ -139,6 +144,7 @@ func (r *folderResource) Read(
 	}
 
 	traceAPICall("GetFolder")
+	ctx = contextWithResourceMetadata(ctx, r, folderID)
 	folderObj, httpResp, err := r.provider.service.GetFolder(ctx, folderID)
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {
@@ -187,6 +193,7 @@ func (r *folderResource) Update(
 		destParentID = plan.ParentId.ValueString()
 	)
 	traceAPICall("UpdateFolder")
+	ctx = contextWithResourceMetadata(ctx, r, plan.ID.ValueString())
 	folderObj, _, err := r.provider.service.UpdateFolder(
 		ctx,
 		plan.ID.ValueString(),
@@ -227,6 +234,7 @@ func (r *folderResource) Delete(
 	}
 
 	traceAPICall("DeleteFolder")
+	ctx = contextWithResourceMetadata(ctx, r, folderID.ValueString())
 	httpResp, err := r.provider.service.DeleteFolder(ctx, folderID.ValueString())
 	if err != nil {
 		if httpResp != nil && httpResp.StatusCode == http.StatusNotFound {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"net/http"
 	"os"
 
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/pkg/client"
@@ -27,10 +28,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 )
 
 // NewService overrides the client method for testing.
 var NewService = client.NewService
+
+var providerResponseTypeName = "cockroach"
 
 // provider satisfies the tfsdk.Provider interface and usually is included
 // with all Resource and DataSource implementations.
@@ -89,24 +93,18 @@ func (p *provider) Configure(
 	}
 	cfg.UserAgent = UserAgent
 
-	logLevel := os.Getenv("TF_LOG")
-	if logLevel == "DEBUG" || logLevel == "TRACE" {
-		cfg.Debug = true
-	} else {
-		logLevel = os.Getenv("TF_LOG_PROVIDER")
-		if logLevel == "DEBUG" || logLevel == "TRACE" {
-			cfg.Debug = true
-		}
-	}
-
 	// retryablehttp gives us automatic retries with exponential backoff.
 	httpClient := retryablehttp.NewClient()
+
 	// The TF framework will pick up the default global logger.
 	// HTTP requests are logged at DEBUG level.
 	httpClient.Logger = &leveledTFLogger{baseCtx: ctx}
 	httpClient.ErrorHandler = retryablehttp.PassthroughErrorHandler
 	httpClient.CheckRetry = retryGetRequestsOnly
 	cfg.HTTPClient = httpClient.StandardClient()
+	cfg.HTTPClient.Transport = ApiWrapperRoundTripper{
+		next: logging.NewLoggingHTTPTransport(cfg.HTTPClient.Transport),
+	}
 
 	cl := client.NewClient(cfg)
 	p.service = NewService(cl)
@@ -119,7 +117,7 @@ func (p *provider) Configure(
 func (p *provider) Metadata(
 	_ context.Context, _ tf_provider.MetadataRequest, resp *tf_provider.MetadataResponse,
 ) {
-	resp.TypeName = "cockroach"
+	resp.TypeName = providerResponseTypeName
 	resp.Version = p.version
 }
 
@@ -181,4 +179,31 @@ func New(version string) func() tf_provider.Provider {
 			version: version,
 		}
 	}
+}
+
+// This type implements the http.RoundTripper interface
+type ApiWrapperRoundTripper struct {
+	// TODO(fitzner): What's a good name for this?
+    next http.RoundTripper
+}
+
+func (rt ApiWrapperRoundTripper) RoundTrip(req *http.Request) (res *http.Response, e error) {
+
+	ctx := req.Context()
+
+	resourceType := ctx.Value(contextValResourceType)
+	resourceIDHash := ctx.Value(contextValResourceIDHash)
+	if resourceType != nil || resourceIDHash != nil {
+		// make a copy
+		req = req.Clone(ctx)
+
+		if resourceType != nil && resourceType.(string) != "" {
+			req.Header.Set("Cc-Tf-Resource-Type", resourceType.(string))
+		}
+		if resourceIDHash != nil && resourceIDHash.(string) != "" {
+			req.Header.Set("Cc-Tf-Resource-Id-Hash", resourceIDHash.(string))
+		}
+	}
+
+	return rt.next.RoundTrip(req)
 }


### PR DESCRIPTION
Today we can roughly report on what resources are being used and how often based on api calls that are made.  We strengthen this reporting by sending back the exact resource that is making the api request and a hashed copy of the ID to aid in determining volume.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
