### PR TITLE
fix incorrect endpoint services examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed private_endpoint_connection documentation issues
+
+## Added
+
 - Enable log export for serverless clusters.
 
 ## [1.7.6] - 2024-06-10

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -16,14 +16,14 @@ Private endpoint connections allow customer applications to connect to a Cockroa
 ## Example with AWS PrivateLink
 
 # Enable the PrivateLink service on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "aws_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 
 # Create a PrivateLink endpoint and associate it with the PrivateLink Service. 
 resource "aws_vpc_endpoint" "my_endpoint" {
   vpc_id             = "vpc-7fc0a543"
-  service_name       = cockroach_private_endpoint_services.services.name
+  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services[0].name
   vpc_endpoint_type  = "Interface"
   subnet_ids         = ["subnet-de0406d2"]
   security_group_ids = ["sg-3f238186"]
@@ -38,7 +38,7 @@ resource "cockroach_private_endpoint_connection" "connection" {
 ## Example with Azure Private Link
 
 # Enable the Private Link service on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "azure_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 
@@ -49,8 +49,8 @@ resource "azurerm_private_endpoint" "my_endpoint" {
   resource_group_name = var.resource_group_name
   subnet_id           = azurerm_subnet.my_subnet.id
   private_service_connection {
-    name                           = cockroach_private_endpoint_connection.services[0].name
-    private_connection_resource_id = cockroach_private_endpoint_connection.services[0].endpoint_service_id
+    name                           = cockroach_private_endpoint_services.azure_cluster_services.services[0].name
+    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services[0].endpoint_service_id
     is_manual_connection           = true
     request_message                = "Azure Private Link test"
   }
@@ -65,7 +65,7 @@ resource "cockroach_private_endpoint_connection" "connection" {
 ## Example with GCP Private Service Connect
 
 # Enable the Private Service Connect services on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "gcp_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 

--- a/examples/resources/cockroach_private_endpoint_connection/resource.tf
+++ b/examples/resources/cockroach_private_endpoint_connection/resource.tf
@@ -1,14 +1,14 @@
 ## Example with AWS PrivateLink
 
 # Enable the PrivateLink service on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "aws_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 
 # Create a PrivateLink endpoint and associate it with the PrivateLink Service. 
 resource "aws_vpc_endpoint" "my_endpoint" {
   vpc_id             = "vpc-7fc0a543"
-  service_name       = cockroach_private_endpoint_services.services.name
+  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services[0].name
   vpc_endpoint_type  = "Interface"
   subnet_ids         = ["subnet-de0406d2"]
   security_group_ids = ["sg-3f238186"]
@@ -23,7 +23,7 @@ resource "cockroach_private_endpoint_connection" "connection" {
 ## Example with Azure Private Link
 
 # Enable the Private Link service on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "azure_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 
@@ -34,8 +34,8 @@ resource "azurerm_private_endpoint" "my_endpoint" {
   resource_group_name = var.resource_group_name
   subnet_id           = azurerm_subnet.my_subnet.id
   private_service_connection {
-    name                           = cockroach_private_endpoint_connection.services[0].name
-    private_connection_resource_id = cockroach_private_endpoint_connection.services[0].endpoint_service_id
+    name                           = cockroach_private_endpoint_services.azure_cluster_services.services[0].name
+    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services[0].endpoint_service_id
     is_manual_connection           = true
     request_message                = "Azure Private Link test"
   }
@@ -50,7 +50,7 @@ resource "cockroach_private_endpoint_connection" "connection" {
 ## Example with GCP Private Service Connect
 
 # Enable the Private Service Connect services on the CockroachDB Cloud cluster.
-resource "cockroach_private_endpoint_services" "services" {
+resource "cockroach_private_endpoint_services" "gcp_cluster_services" {
   cluster_id = cockroach_cluster.my_cluster.id
 }
 


### PR DESCRIPTION
Previously, the private_endpoint_connection resource examples was using the private_endpoint_services resource incorrectly.  This change fixes that and updates the generated documentation.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [x] Example(s)
