### PR TITLE
updated user_role_grants docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- Update the user_role_grants resource docs to indicate the requirement of ORG_MEMBER.
+
 - Fixed private_endpoint_connection documentation issues
 
 ## Added

--- a/docs/resources/user_role_grants.md
+++ b/docs/resources/user_role_grants.md
@@ -3,12 +3,12 @@
 page_title: "cockroach_user_role_grants Resource - terraform-provider-cockroach"
 subcategory: ""
 description: |-
-  Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the cockroachuserrole_grant user_role_grant resource for non-authoritative role grants.
+  Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the cockroachuserrole_grant user_role_grant resource for non-authoritative role grants.  ORG_MEMBER is a required role and must be included.
 ---
 
 # cockroach_user_role_grants (Resource)
 
-Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the [cockroach_user_role_grant](user_role_grant) resource for non-authoritative role grants.
+Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the [cockroach_user_role_grant](user_role_grant) resource for non-authoritative role grants.  ORG_MEMBER is a required role and must be included.
 
 ## Example Usage
 
@@ -20,6 +20,11 @@ variable "user_id" {
 resource "cockroach_user_role_grants" "cockroach" {
   user_id = var.user_id
   roles = [
+    {
+      role_name     = "ORG_MEMBER",
+      resource_type = "ORGANIZATION",
+      resource_id   = ""
+    },
     {
       role_name     = "ORG_ADMIN",
       resource_type = "ORGANIZATION",
@@ -44,7 +49,7 @@ resource "cockroach_user_role_grants" "cockroach" {
 
 ### Required
 
-- `roles` (Attributes Set) (see [below for nested schema](#nestedatt--roles))
+- `roles` (Attributes Set) The list of roles to include. ORG_MEMBER must be included. (see [below for nested schema](#nestedatt--roles))
 - `user_id` (String) ID of the user to grant these roles to.
 
 ### Read-Only

--- a/examples/resources/cockroach_user_role_grants/resource.tf
+++ b/examples/resources/cockroach_user_role_grants/resource.tf
@@ -6,6 +6,11 @@ resource "cockroach_user_role_grants" "cockroach" {
   user_id = var.user_id
   roles = [
     {
+      role_name     = "ORG_MEMBER",
+      resource_type = "ORGANIZATION",
+      resource_id   = ""
+    },
+    {
       role_name     = "ORG_ADMIN",
       resource_type = "ORGANIZATION",
       resource_id   = ""

--- a/internal/provider/user_role_grants_resource.go
+++ b/internal/provider/user_role_grants_resource.go
@@ -39,7 +39,7 @@ func (r *userRoleGrantsResource) Schema(
 	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the [cockroach_user_role_grant](user_role_grant) resource for non-authoritative role grants.",
+		MarkdownDescription: "Manage all the role grants for a user. This resource is authoritative.  If role grants are added elsewhere, for example, via the console UI or another terraform project, using this resource will try to reset them. Use the [cockroach_user_role_grant](user_role_grant) resource for non-authoritative role grants.  ORG_MEMBER is a required role and must be included.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -54,6 +54,7 @@ func (r *userRoleGrantsResource) Schema(
 			},
 			"roles": schema.SetNestedAttribute{
 				Required: true,
+				Description: "The list of roles to include. ORG_MEMBER must be included.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"role_name": schema.StringAttribute{


### PR DESCRIPTION
Previously, it was unknown that ORG_MEMBER was required to be passed. Ideally this would not be the case but as a quick fix, we update the docs and examples to indicate that it is required.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [x] Example(s)
