### PR TITLE
Adding a warning to the README about the need to use a recent version of the provider for private endpoints 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added warning about using private endpoints with old versions.
+
 - Enable log export for serverless clusters.
 
 ## [1.7.6] - 2024-06-10

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md](DEVELOPMENT.md).
 
-**Note: This is a preview release, suitable only for experimental use.**
-
 ## Get Started
+
+** If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) (AWS PrivateLink, GCP Private Service Connect, Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later. **
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md
 
 ## Get Started
 
-### Warning: Use of *private endpoints* requires >=v1.7.6
-If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) ([AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink), [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect), Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later.
+### _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest).
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md
 
 ## Get Started
 
-** If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) (AWS PrivateLink, GCP Private Service Connect, Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later. **
+**If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) (AWS PrivateLink, GCP Private Service Connect, Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later.**
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md
 
 ## Get Started
 
-**If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) (AWS PrivateLink, GCP Private Service Connect, Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later.**
+### Warning: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints]([url](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md)) ([AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink), [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect), Azure Private Link) you must upgrade to [version 1.7.6]([url](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6)) or later.
 
 ### Prerequisites
 

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -6,7 +6,7 @@ description: |-
   Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.
 ---
 
-# _Warning_: Use of *private endpoints* requires >=v1.7.6
+## _Warning_: Use of *private endpoints* requires >=v1.7.6
 If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
 - [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
 - [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -4,19 +4,25 @@ page_title: "cockroach_private_endpoint_connection Resource - terraform-provider
 subcategory: ""
 description: |-
   Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.
+  Warning: Use of private endpoints requires >=v1.7.6
+  If you intend to use this provider to provision private endpoints https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md:
+  - AWS PrivateLink https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink
+  - GCP Private Service Connect https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect
+  - Azure Private Link https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure
+  You must install/upgrade to version 1.7.6 https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6 or later https://registry.terraform.io/providers/cockroachdb/cockroach/latest
 ---
-
-## _Warning_: Use of *private endpoints* requires >=v1.7.6
-If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
-- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
-- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
-- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
-
-You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest).
 
 # cockroach_private_endpoint_connection (Resource)
 
 Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.
+
+### _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+	
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)
 
 ## Example Usage
 

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -6,6 +6,14 @@ description: |-
   Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.
 ---
 
+# _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest).
+
 # cockroach_private_endpoint_connection (Resource)
 
 Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -6,7 +6,7 @@ description: |-
   PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.
 ---
 
-# _Warning_: Use of *private endpoints* requires >=v1.7.6
+## _Warning_: Use of *private endpoints* requires >=v1.7.6
 If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
 - [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
 - [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -6,6 +6,14 @@ description: |-
   PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.
 ---
 
+# _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest).
+
 # cockroach_private_endpoint_services (Resource)
 
 PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -4,19 +4,25 @@ page_title: "cockroach_private_endpoint_services Resource - terraform-provider-c
 subcategory: ""
 description: |-
   PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.
+  Warning: Use of private endpoints requires >=v1.7.6
+  If you intend to use this provider to provision private endpoints https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md:
+  - AWS PrivateLink https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink
+  - GCP Private Service Connect https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect
+  - Azure Private Link https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure
+  You must install/upgrade to version 1.7.6 https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6 or later https://registry.terraform.io/providers/cockroachdb/cockroach/latest
 ---
-
-## _Warning_: Use of *private endpoints* requires >=v1.7.6
-If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
-- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
-- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
-- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
-
-You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest).
 
 # cockroach_private_endpoint_services (Resource)
 
 PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.
+	
+### _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+	
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)
 
 ## Example Usage
 

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -50,6 +50,19 @@ func (r *privateEndpointConnectionResource) Schema(
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.",
 		Attributes: map[string]schema.Attribute{
+			"warning": schema.StringAttribute{
+				Computed: true,
+				MarkdownDescription: `## _Warning_: Use of *private endpoints* requires >=v1.7.6
+	If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+	- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+	- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+	- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+	
+	You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)`,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Used with `terraform import`. Format is \"<cluster ID>:<endpoint ID>\".",

--- a/internal/provider/private_endpoint_connection_resource.go
+++ b/internal/provider/private_endpoint_connection_resource.go
@@ -48,21 +48,16 @@ func (r *privateEndpointConnectionResource) Schema(
 	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.",
-		Attributes: map[string]schema.Attribute{
-			"warning": schema.StringAttribute{
-				Computed: true,
-				MarkdownDescription: `## _Warning_: Use of *private endpoints* requires >=v1.7.6
-	If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
-	- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
-	- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
-	- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+		MarkdownDescription: `Private endpoint connections allow customer applications to connect to a CockroachDB Cloud cluster without traversing the public internet. All application-database traffic remains within the cloud-provider network.
+
+### _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
 	
-	You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)`,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
-			},
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)`,
+		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "Used with `terraform import`. Format is \"<cluster ID>:<endpoint ID>\".",

--- a/internal/provider/private_endpoint_services_resource.go
+++ b/internal/provider/private_endpoint_services_resource.go
@@ -42,21 +42,16 @@ type privateEndpointServicesResource struct {
 const endpointServicesCreateTimeout = time.Hour
 
 var endpointServicesSchema = schema.Schema{
-	MarkdownDescription: "PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.",
-	Attributes: map[string]schema.Attribute{
-		"warning": schema.StringAttribute{
-			Computed: true,
-			MarkdownDescription: `## _Warning_: Use of *private endpoints* requires >=v1.7.6
+	MarkdownDescription: `PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.
+	
+### _Warning_: Use of *private endpoints* requires >=v1.7.6
 If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
 - [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
 - [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
 - [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
-
+	
 You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)`,
-			PlanModifiers: []planmodifier.String{
-				stringplanmodifier.UseStateForUnknown(),
-			},
-		},
+	Attributes: map[string]schema.Attribute{
 		"cluster_id": schema.StringAttribute{
 			Required: true,
 			PlanModifiers: []planmodifier.String{

--- a/internal/provider/private_endpoint_services_resource.go
+++ b/internal/provider/private_endpoint_services_resource.go
@@ -44,6 +44,19 @@ const endpointServicesCreateTimeout = time.Hour
 var endpointServicesSchema = schema.Schema{
 	MarkdownDescription: "PrivateEndpointServices contains services that allow for private connectivity to the CockroachDB Cloud cluster.",
 	Attributes: map[string]schema.Attribute{
+		"warning": schema.StringAttribute{
+			Computed: true,
+			MarkdownDescription: `## _Warning_: Use of *private endpoints* requires >=v1.7.6
+If you intend to use this provider to provision [private endpoints](https://github.com/cockroachdb/terraform-provider-cockroach/blob/main/docs/resources/private_endpoint_connection.md):
+- [AWS PrivateLink](https://www.cockroachlabs.com/docs/cockroachcloud/aws-privatelink)
+- [GCP Private Service Connect](https://www.cockroachlabs.com/docs/cockroachcloud/connect-to-your-cluster#gcp-private-service-connect)
+- [Azure Private Link](https://www.cockroachlabs.com/docs/cockroachcloud/cockroachdb-dedicated-on-azure)
+
+You must install/upgrade to [version 1.7.6](https://github.com/cockroachdb/terraform-provider-cockroach/releases/tag/v1.7.6) or [later](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)`,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
+		},
 		"cluster_id": schema.StringAttribute{
 			Required: true,
 			PlanModifiers: []planmodifier.String{


### PR DESCRIPTION
Adding a warning to the README about the need to use a recent version of the provider for private endpoints to avoid a recently discovered bug in older versions.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
