### PR TITLE
provider: add services map to private_endpoint_services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable log export for serverless clusters.
 
+- Add services_map to private_endpoint_services resource.
+
 ## [1.7.6] - 2024-06-10
 
 ## Fixed

--- a/docs/resources/private_endpoint_connection.md
+++ b/docs/resources/private_endpoint_connection.md
@@ -23,7 +23,7 @@ resource "cockroach_private_endpoint_services" "aws_cluster_services" {
 # Create a PrivateLink endpoint and associate it with the PrivateLink Service. 
 resource "aws_vpc_endpoint" "my_endpoint" {
   vpc_id             = "vpc-7fc0a543"
-  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services[0].name
+  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services_map["us-east-1"].name
   vpc_endpoint_type  = "Interface"
   subnet_ids         = ["subnet-de0406d2"]
   security_group_ids = ["sg-3f238186"]
@@ -49,8 +49,8 @@ resource "azurerm_private_endpoint" "my_endpoint" {
   resource_group_name = var.resource_group_name
   subnet_id           = azurerm_subnet.my_subnet.id
   private_service_connection {
-    name                           = cockroach_private_endpoint_services.azure_cluster_services.services[0].name
-    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services[0].endpoint_service_id
+    name                           = cockroach_private_endpoint_services.azure_cluster_services.services_map["eastus2"].name
+    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services_map["eastus2"].endpoint_service_id
     is_manual_connection           = true
     request_message                = "Azure Private Link test"
   }

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -33,6 +33,7 @@ resource "cockroach_private_endpoint_services" "cockroach" {
 
 - `id` (String) Always matches the cluster ID. Required by Terraform.
 - `services` (Attributes List) (see [below for nested schema](#nestedatt--services))
+- `services_map` (Attributes Map) a map of services keyed by the region name (see [below for nested schema](#nestedatt--services_map))
 
 <a id="nestedatt--services"></a>
 ### Nested Schema for `services`
@@ -49,6 +50,30 @@ Read-Only:
 
 <a id="nestedatt--services--aws"></a>
 ### Nested Schema for `services.aws`
+
+Read-Only:
+
+- `availability_zone_ids` (List of String) AZ IDs users should create their VPCs in to minimize their cost.
+- `service_id` (String) Server side ID of the PrivateLink connection.
+- `service_name` (String) AWS service name used to create endpoints.
+
+
+
+<a id="nestedatt--services_map"></a>
+### Nested Schema for `services_map`
+
+Read-Only:
+
+- `availability_zone_ids` (List of String) Availability Zone IDs of the private endpoint service. It is recommended, for cost optimization purposes, to create the private endpoint spanning these same availability zones. For more information, see data transfer cost information for your cloud provider.
+- `aws` (Attributes, Deprecated) (see [below for nested schema](#nestedatt--services_map--aws))
+- `cloud_provider` (String) Cloud provider associated with this service.
+- `endpoint_service_id` (String) Server side ID of the private endpoint connection.
+- `name` (String) Name of the endpoint service.
+- `region_name` (String) Cloud provider region code associated with this service.
+- `status` (String) Operation status of the service.
+
+<a id="nestedatt--services_map--aws"></a>
+### Nested Schema for `services_map.aws`
 
 Read-Only:
 

--- a/examples/resources/cockroach_private_endpoint_connection/resource.tf
+++ b/examples/resources/cockroach_private_endpoint_connection/resource.tf
@@ -8,7 +8,7 @@ resource "cockroach_private_endpoint_services" "aws_cluster_services" {
 # Create a PrivateLink endpoint and associate it with the PrivateLink Service. 
 resource "aws_vpc_endpoint" "my_endpoint" {
   vpc_id             = "vpc-7fc0a543"
-  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services[0].name
+  service_name       = cockroach_private_endpoint_services.aws_cluster_services.services_map["us-east-1"].name
   vpc_endpoint_type  = "Interface"
   subnet_ids         = ["subnet-de0406d2"]
   security_group_ids = ["sg-3f238186"]
@@ -34,8 +34,8 @@ resource "azurerm_private_endpoint" "my_endpoint" {
   resource_group_name = var.resource_group_name
   subnet_id           = azurerm_subnet.my_subnet.id
   private_service_connection {
-    name                           = cockroach_private_endpoint_services.azure_cluster_services.services[0].name
-    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services[0].endpoint_service_id
+    name                           = cockroach_private_endpoint_services.azure_cluster_services.services_map["eastus2"].name
+    private_connection_resource_id = cockroach_private_endpoint_services.azure_cluster_services.services_map["eastus2"].endpoint_service_id
     is_manual_connection           = true
     request_message                = "Azure Private Link test"
   }

--- a/examples/workflows/aws_privatelink/main.tf
+++ b/examples/workflows/aws_privatelink/main.tf
@@ -145,7 +145,7 @@ resource "aws_subnet" "example" {
 
 resource "aws_vpc_endpoint" "example" {
   vpc_id             = aws_vpc.example.id
-  service_name       = cockroach_private_endpoint_services.example.services[0].aws.service_name
+  service_name       = cockroach_private_endpoint_services.example.services_map[var.aws_region].name
   vpc_endpoint_type  = "Interface"
   security_group_ids = [aws_security_group.example.id]
   subnet_ids         = [for s in aws_subnet.example : s.id]

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -118,9 +118,10 @@ type PrivateEndpointService struct {
 }
 
 type PrivateEndpointServices struct {
-	ClusterID types.String `tfsdk:"cluster_id"`
-	Services  types.List   `tfsdk:"services"`
-	ID        types.String `tfsdk:"id"`
+	ClusterID   types.String `tfsdk:"cluster_id"`
+	Services    types.List   `tfsdk:"services"`
+	ServicesMap types.Map    `tfsdk:"services_map"`
+	ID          types.String `tfsdk:"id"`
 }
 
 type PrivateEndpointConnection struct {

--- a/internal/provider/private_endpoint_services_resource.go
+++ b/internal/provider/private_endpoint_services_resource.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -57,60 +58,70 @@ var endpointServicesSchema = schema.Schema{
 			},
 			MarkdownDescription: "Always matches the cluster ID. Required by Terraform.",
 		},
+		"services_map": schema.MapNestedAttribute{
+			Computed:    true,
+			Description: "a map of services keyed by the region name",
+			PlanModifiers: []planmodifier.Map{
+				mapplanmodifier.UseStateForUnknown(),
+			},
+			NestedObject: serviceObject,
+		},
 		"services": schema.ListNestedAttribute{
 			Computed: true,
 			PlanModifiers: []planmodifier.List{
 				listplanmodifier.UseStateForUnknown(),
 			},
-			NestedObject: schema.NestedAttributeObject{
-				Attributes: map[string]schema.Attribute{
-					"region_name": schema.StringAttribute{
-						Computed:    true,
-						Description: "Cloud provider region code associated with this service.",
-					},
-					"cloud_provider": schema.StringAttribute{
-						Computed:    true,
-						Description: "Cloud provider associated with this service.",
-					},
-					"status": schema.StringAttribute{
-						Computed:    true,
-						Description: "Operation status of the service.",
-					},
-					"name": schema.StringAttribute{
-						Computed:    true,
-						Description: "Name of the endpoint service.",
-					},
-					"endpoint_service_id": schema.StringAttribute{
-						Computed:    true,
-						Description: "Server side ID of the private endpoint connection.",
-					},
-					"availability_zone_ids": schema.ListAttribute{
-						Computed:            true,
-						ElementType:         types.StringType,
-						MarkdownDescription: "Availability Zone IDs of the private endpoint service. It is recommended, for cost optimization purposes, to create the private endpoint spanning these same availability zones. For more information, see data transfer cost information for your cloud provider.",
-					},
-					"aws": schema.SingleNestedAttribute{
-						DeprecationMessage: "nested aws fields have been moved one level up. These fields will be removed in a future version",
-						Computed:           true,
-						PlanModifiers: []planmodifier.Object{
-							objectplanmodifier.UseStateForUnknown(),
-						},
-						Attributes: map[string]schema.Attribute{
-							"service_name": schema.StringAttribute{
-								Computed:    true,
-								Description: "AWS service name used to create endpoints.",
-							},
-							"service_id": schema.StringAttribute{
-								Computed:    true,
-								Description: "Server side ID of the PrivateLink connection.",
-							},
-							"availability_zone_ids": schema.ListAttribute{
-								Computed:            true,
-								ElementType:         types.StringType,
-								MarkdownDescription: "AZ IDs users should create their VPCs in to minimize their cost.",
-							},
-						},
-					},
+			NestedObject: serviceObject,
+		},
+	},
+}
+
+var serviceObject = schema.NestedAttributeObject{
+	Attributes: map[string]schema.Attribute{
+		"region_name": schema.StringAttribute{
+			Computed:    true,
+			Description: "Cloud provider region code associated with this service.",
+		},
+		"cloud_provider": schema.StringAttribute{
+			Computed:    true,
+			Description: "Cloud provider associated with this service.",
+		},
+		"status": schema.StringAttribute{
+			Computed:    true,
+			Description: "Operation status of the service.",
+		},
+		"name": schema.StringAttribute{
+			Computed:    true,
+			Description: "Name of the endpoint service.",
+		},
+		"endpoint_service_id": schema.StringAttribute{
+			Computed:    true,
+			Description: "Server side ID of the private endpoint connection.",
+		},
+		"availability_zone_ids": schema.ListAttribute{
+			Computed:            true,
+			ElementType:         types.StringType,
+			MarkdownDescription: "Availability Zone IDs of the private endpoint service. It is recommended, for cost optimization purposes, to create the private endpoint spanning these same availability zones. For more information, see data transfer cost information for your cloud provider.",
+		},
+		"aws": schema.SingleNestedAttribute{
+			DeprecationMessage: "nested aws fields have been moved one level up. These fields will be removed in a future version",
+			Computed:           true,
+			PlanModifiers: []planmodifier.Object{
+				objectplanmodifier.UseStateForUnknown(),
+			},
+			Attributes: map[string]schema.Attribute{
+				"service_name": schema.StringAttribute{
+					Computed:    true,
+					Description: "AWS service name used to create endpoints.",
+				},
+				"service_id": schema.StringAttribute{
+					Computed:    true,
+					Description: "Server side ID of the PrivateLink connection.",
+				},
+				"availability_zone_ids": schema.ListAttribute{
+					Computed:            true,
+					ElementType:         types.StringType,
+					MarkdownDescription: "AZ IDs users should create their VPCs in to minimize their cost.",
 				},
 			},
 		},
@@ -277,6 +288,21 @@ func loadEndpointServicesIntoTerraformState(
 		endpointServicesSchema.Attributes["services"].(schema.ListNestedAttribute).NestedObject.Type(),
 		services,
 	)
+
+	servicesMap := map[string]PrivateEndpointService{}
+	for _, svc := range services {
+		servicesMap[svc.RegionName.ValueString()] = svc
+	}
+
+	var diags2 diag.Diagnostics
+	state.ServicesMap, diags2 = types.MapValueFrom(
+		ctx,
+		endpointServicesSchema.Attributes["services_map"].(schema.MapNestedAttribute).NestedObject.Type(),
+		servicesMap,
+	)
+
+	diags.Append(diags2...)
+
 	return diags
 }
 

--- a/internal/provider/private_endpoint_services_resource_test.go
+++ b/internal/provider/private_endpoint_services_resource_test.go
@@ -227,11 +227,16 @@ func testPrivateEndpointServicesResource(
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(clusterResourceName, "name", clusterName),
 		resource.TestCheckResourceAttr(resourceName, "services.#", strconv.Itoa(numExpectedServices)),
+		resource.TestCheckResourceAttr(resourceName, "services_map.%", strconv.Itoa(numExpectedServices)),
 	}
 	for i := 0; i < numExpectedServices; i++ {
 		svc := fmt.Sprintf("services.%d", i)
 		checks = append(checks,
 			resource.TestCheckResourceAttr(resourceName, svc+".status", string(client.PRIVATEENDPOINTSERVICESTATUSTYPE_AVAILABLE)),
+		)
+
+		checks = append(checks,
+			resource.TestCheckResourceAttrPair(resourceName, svc, resourceName, "services_map.us-east-1"),
 		)
 
 		if cloud == client.CLOUDPROVIDERTYPE_AWS {

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package mapplanmodifier provides plan modifiers for types.Map attributes.
+package mapplanmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Map {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.MapRequest, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Map {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyMap implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyMap(ctx context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if_configured.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Map {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.MapRequest, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/requires_replace_if_func.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.MapRequest, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier/use_state_for_unknown.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mapplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+func UseStateForUnknown() planmodifier.Map {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyMap implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,6 +209,7 @@ github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults
 github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier
+github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier


### PR DESCRIPTION
Previously, the private_endpoint_services resource contains the regional services in a list. This made it hard for users to access the service for a given region. This commit adds a service map that contains all the services but are keyed by the cloud region.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
