### PR TITLE
private_endpoints_service: wait for all regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Ensure all cluster regions are ready when waiting or private endpoint
+  services.
 - Fixed an issue where enabling log export configs did not account for lock errors.
 - Exporting Cloudwatch metrics on a serverless Cluster no longer generates an error.
 - Exporting Cloudwatch metrics while on the Basic plan now generates an error.

--- a/docs/resources/private_endpoint_services.md
+++ b/docs/resources/private_endpoint_services.md
@@ -46,7 +46,7 @@ resource "cockroach_private_endpoint_services" "cockroach" {
 ### Read-Only
 
 - `id` (String) Always matches the cluster ID. Required by Terraform.
-- `services` (Attributes List) (see [below for nested schema](#nestedatt--services))
+- `services` (Attributes List) A list of regional private endpoint services for the cluster (see [below for nested schema](#nestedatt--services))
 - `services_map` (Attributes Map) a map of services keyed by the region name (see [below for nested schema](#nestedatt--services_map))
 
 <a id="nestedatt--services"></a>


### PR DESCRIPTION
Previously, when waiting for private endpoints service creation, the resource could be considered ready if a single resource was ready and others were not yet created. This commit fixes the bug by explicitly waiting for all regional services to be AVAILABLE.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
