### PR TITLE
add downgrade tests from STANDARD to BASIC

### DIFF
--- a/examples/workflows/cockroach_folder/main.tf
+++ b/examples/workflows/cockroach_folder/main.tf
@@ -73,6 +73,7 @@ resource "cockroach_user_role_grant" "cluster_creator_grant" {
 resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = var.cloud_provider
+  plan           = "STANDARD"
   serverless = {
     usage_limits = {
       provisioned_vcpus = var.provisioned_vcpus

--- a/examples/workflows/cockroach_serverless_cluster/main.tf
+++ b/examples/workflows/cockroach_serverless_cluster/main.tf
@@ -51,6 +51,7 @@ provider "cockroach" {
 resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = var.cloud_provider
+  plan           = "STANDARD"
   serverless = {
     usage_limits = {
       provisioned_vcpus = var.provisioned_vcpus

--- a/examples/workflows/cockroach_user_role_grants/main.tf
+++ b/examples/workflows/cockroach_user_role_grants/main.tf
@@ -47,6 +47,7 @@ provider "cockroach" {
 resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = var.cloud_provider
+  plan           = "STANDARD"
   serverless = {
     usage_limits = {
       provisioned_vcpus = var.provisioned_vcpus


### PR DESCRIPTION
Add tests for downgrading from the STANDARD plan to the BASIC plan.

**Commit checklist**
- [X] Changelog
- [X] Doc gen (`make generate`)
- [X] Integration test(s)
- [X] Acceptance test(s)
- [X] Example(s)
