### PR TITLE
[CC-29279] improve user_role_grant/s testing with sa user

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,7 +123,9 @@ process. Unit tests are great, but rare since TF provider methods don't usually 
 
 **It's generally a good idea to run acceptance tests affected by your change manually before submitting a PR.** If
 you're using GoLand, you can run them individually, setting `TF_ACC=1` and setting `COCKROACH_SERVER` and
-`COCKROACH_API_KEY` to appropriate values.
+`COCKROACH_API_KEY` to appropriate values. Please ensure the service account associated with the provided
+`COCKROACH_API_KEY` has the necessary role/permissions (Org Admin, Billing Coordinator, Cluster Admin, Folder Admin) to
+run the tests.
 
 Getting the mock calls right for integration tests can be challenging. You may be surprised at how many read calls are
 issued at each stage. Some optional logging has been enabled which can help

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -698,11 +698,12 @@ func TestIntegrationDedicatedClusterResource(t *testing.T) {
 		})
 
 	s.EXPECT().GetCluster(gomock.Any(), clusterID).
-		Return(&firstUpdateCluster, httpOk, nil).Times(7)
+		Return(&firstUpdateCluster, httpOk, nil).Times(6)
 
 	// Failed Delete Attempt
 
 	// Second Update
+
 	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).
 		DoAndReturn(func(context.Context, string, *client.UpdateClusterSpecification,
 		) (*client.Cluster, *http.Response, error) {


### PR DESCRIPTION
Previously, the top level terraform user was used for testing in the user_role_grant_resource and user_role_grants_resource tests. Changes to this user are fragile and could affect other tests or require manual fixing on failure. This commit updates the user associated with those tests to be a newly created service account user. Additionally this commit also includes a new acceptance test for
user_role_grants_resource.

Checklist is unnecessary since the changes only affect tests

