### PR TITLE
pass Plan to CreateCluster if it was specified by the user

### DIFF
--- a/internal/provider/service_account_resource.go
+++ b/internal/provider/service_account_resource.go
@@ -197,7 +197,7 @@ func (r *serviceAccountResource) Update(
 	}
 
 	// Only send the description if the value is present in resource.
-	if !(plan.Description.IsNull() || plan.Description.IsUnknown()) {
+	if IsKnown(plan.Description) {
 		updateSpec.SetDescription(plan.Description.ValueString())
 	}
 


### PR DESCRIPTION
Previously, the Plan field was not passed to the CreateCluster API, even if
it was explicitly set by the user. This prevented the server from validating
the cluster configuration. For example, the server was not able to return
an error when Plan=BASIC and provisioned_vcpus are set. The fix is to pass
the Plan field to CreateCluster if the user explicitly sets it.

**Commit checklist**
- [X] Changelog
- [X] Doc gen (`make generate`)
- [X] Integration test(s)
- [X] Acceptance test(s)
- [X] Example(s)
