### PR TITLE
Add upgrade_type attribute to cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `upgrade_type` was added as an attribute for serverless clusters.
 - New `STANDARD` clusters with provisioned serverless capacity.
 - Ability to upgrade from `BASIC` plan to `STANDARD` plan.
 

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -79,6 +79,7 @@ Read-Only:
 
 - `routing_id` (String) Cluster identifier in a connection string.
 - `spend_limit` (Number, Deprecated) Spend limit in US cents.
+- `upgrade_type` (String) Dictates the behavior of cockroach major version upgrades.
 - `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))
 
 <a id="nestedatt--serverless--usage_limits"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -38,6 +38,7 @@ resource "cockroach_cluster" "standard" {
     usage_limits = {
       provisioned_vcpus = 2
     }
+    upgrade_type = "AUTOMATIC"
   }
   regions = [
     {
@@ -132,6 +133,9 @@ Read-Only:
 Optional:
 
 - `spend_limit` (Number, Deprecated) Spend limit in US cents.
+- `upgrade_type` (String) Dictates the behavior of cockroach major version upgrades. If plan type is 'BASIC', this attribute must be left empty or set to 'AUTOMATIC'. Allowed values are: 
+  * MANUAL
+  * AUTOMATIC
 - `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))
 
 Read-Only:

--- a/examples/resources/cockroach_cluster/resource.tf
+++ b/examples/resources/cockroach_cluster/resource.tf
@@ -23,6 +23,7 @@ resource "cockroach_cluster" "standard" {
     usage_limits = {
       provisioned_vcpus = 2
     }
+    upgrade_type = "AUTOMATIC"
   }
   regions = [
     {

--- a/examples/workflows/cockroach_standard_cluster/main.tf
+++ b/examples/workflows/cockroach_standard_cluster/main.tf
@@ -37,6 +37,12 @@ variable "cloud_provider_regions" {
   default  = ["us-central1"]
 }
 
+variable "upgrade_type" {
+  type     = string
+  nullable = false
+  default  = "AUTOMATIC"
+}
+
 terraform {
   required_providers {
     cockroach = {
@@ -56,6 +62,7 @@ resource "cockroach_cluster" "example" {
     usage_limits = {
       provisioned_vcpus = var.provisioned_vcpus
     }
+    upgrade_type = var.upgrade_type
   }
   regions = [for r in var.cloud_provider_regions : { name = r }]
 }

--- a/internal/provider/allowlist_resource_test.go
+++ b/internal/provider/allowlist_resource_test.go
@@ -161,6 +161,7 @@ func TestIntegrationAllowlistEntryResource(t *testing.T) {
 				Config: client.ClusterConfig{
 					Serverless: &client.ServerlessClusterConfig{
 						RoutingId: "routing-id",
+						UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					},
 				},
 				Regions: []client.Region{

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -89,6 +89,10 @@ func (d *clusterDataSource) Schema(
 						Computed:    true,
 						Description: "Cluster identifier in a connection string.",
 					},
+					"upgrade_type": schema.StringAttribute{
+						Computed:    true,
+						Description: "Dictates the behavior of cockroach major version upgrades.",
+					},
 				},
 			},
 			"dedicated": schema.SingleNestedAttribute{

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -56,6 +56,14 @@ type clusterResource struct {
 	provider *provider
 }
 
+var AllowedUpgradeTypeTypeEnumValueStrings = func() []string {
+	var strings []string
+	for i := range client.AllowedUpgradeTypeTypeEnumValues {
+		strings = append(strings, string(client.AllowedUpgradeTypeTypeEnumValues[i]))
+	}
+	return strings
+}()
+
 var regionSchema = schema.NestedAttributeObject{
 	Attributes: map[string]schema.Attribute{
 		"name": schema.StringAttribute{
@@ -178,6 +186,16 @@ func (r *clusterResource) Schema(
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Description: "Cluster identifier in a connection string.",
+					},
+					"upgrade_type": schema.StringAttribute{
+						Computed: true,
+						Optional: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
+						Validators:  []validator.String{stringvalidator.OneOf(AllowedUpgradeTypeTypeEnumValueStrings...)},
+						MarkdownDescription: "Dictates the behavior of cockroach major version upgrades. If plan type is 'BASIC', this attribute must be left empty or set to 'AUTOMATIC'. Allowed values are: " +
+							formatEnumMarkdownList(AllowedUpgradeTypeTypeEnumValueStrings),
 					},
 				},
 			},
@@ -361,6 +379,16 @@ func (r *clusterResource) Create(
 			serverless.UsageLimits.RequestUnitLimit = usageLimits.RequestUnitLimit.ValueInt64Pointer()
 			serverless.UsageLimits.StorageMibLimit = usageLimits.StorageMibLimit.ValueInt64Pointer()
 			serverless.UsageLimits.ProvisionedVcpus = usageLimits.ProvisionedVcpus.ValueInt64Pointer()
+		}
+
+		upgradeTypeString := plan.ServerlessConfig.UpgradeType.ValueString()
+		if upgradeTypeString != "" {
+			upgradeType, err := client.NewUpgradeTypeTypeFromValue(upgradeTypeString)
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid Upgrade Type", err.Error())
+			} else {
+				serverless.SetUpgradeType(*upgradeType)
+			}
 		}
 
 		clusterSpec.SetServerless(*serverless)
@@ -758,6 +786,30 @@ func (r *clusterResource) Update(
 			serverless.UsageLimits.StorageMibLimit = usageLimits.StorageMibLimit.ValueInt64Pointer()
 			serverless.UsageLimits.ProvisionedVcpus = usageLimits.ProvisionedVcpus.ValueInt64Pointer()
 		}
+
+		planUpgradeType := plan.ServerlessConfig.UpgradeType.ValueString()
+		stateUpgradeType := state.ServerlessConfig.UpgradeType.ValueString()
+
+		// Only add the upgrade_type if it changed.
+		if planUpgradeType != "" && planUpgradeType != stateUpgradeType {
+
+			upgradeTypePtr, err := client.NewUpgradeTypeTypeFromValue(plan.ServerlessConfig.UpgradeType.ValueString())
+			if err != nil {
+				resp.Diagnostics.AddError("Invalid value for upgrade_type", err.Error())
+				return
+			}
+			upgradeType := *upgradeTypePtr
+
+			// Check this combination explicitly to provide a better message
+			// than the ccapi is currently returning for this case.
+			if plan.Plan.ValueString() == string(client.PLANTYPE_BASIC) && upgradeType == client.UPGRADETYPETYPE_MANUAL {
+				resp.Diagnostics.AddError("Invalid value for upgrade_type", "plan type BASIC does not allow upgrade_type MANUAL")
+				return
+			}
+
+			serverless.SetUpgradeType(upgradeType)
+		}
+
 		clusterReq.SetServerless(*serverless)
 	} else if cfg := plan.DedicatedConfig; cfg != nil {
 		dedicated := client.NewDedicatedClusterUpdateSpecification()
@@ -823,7 +875,6 @@ func (r *clusterResource) Update(
 	}
 
 	traceAPICall("UpdateCluster")
-
 	clusterObj, _, err := r.provider.service.UpdateCluster(ctx, state.ID.ValueString(), clusterReq)
 	if err != nil {
 		resp.Diagnostics.AddError(
@@ -982,6 +1033,7 @@ func loadClusterToTerraformState(
 	if clusterObj.Config.Serverless != nil {
 		serverlessConfig := &ServerlessClusterConfig{
 			RoutingId: types.StringValue(clusterObj.Config.Serverless.RoutingId),
+			UpgradeType: types.StringValue(string(clusterObj.Config.Serverless.UpgradeType)),
 		}
 
 		if plan != nil && plan.ServerlessConfig != nil && IsKnown(plan.ServerlessConfig.SpendLimit) {

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -68,14 +68,90 @@ func TestAccServerlessClusterResource(t *testing.T) {
 			onDemandSingleRegionClusterWithLimitsStep(clusterName, "BASIC", 1_000_000, 1024),
 			onDemandSingleRegionClusterNoLimitsStep(clusterName, defaultPlanType),
 			onDemandSingleRegionClusterWithLimitsStep(clusterName, "BASIC", 10_000_000_000, 102_400),
-			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType),
+			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType, nil /* upgradeType */),
 			onDemandSingleRegionClusterNoLimitsStep(clusterName, "BASIC"),
 			legacyServerlessClusterWithSpendLimitStep(clusterName, 10_00),
-			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType),
+			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType, nil /* upgradeType */),
 			// Upgrade to STANDARD.
-			provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6),
+			provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6, nil),
 			// Downgrade to BASIC.
-			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC"),
+			onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", nil /* upgradeType */),
+		},
+	})
+}
+
+// TestAccServerlessUpgradeType is an acceptance test focused only on testing
+// upgrade_type.  Since the serverless tests are relatively quick, no
+// integration test version of this is added.  It will be skipped if TF_ACC
+// isn't set.
+func TestAccServerlessUpgradeType(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("%s-serverless-%s", tfTestPrefix, GenerateRandomString(2))
+	checkUpgradeTypeResources := func(upgradeType client.UpgradeTypeType) resource.TestCheckFunc {
+		return resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttr(serverlessResourceName, "serverless.upgrade_type", string(upgradeType)),
+			resource.TestCheckResourceAttr(serverlessDataSourceName , "serverless.upgrade_type", string(upgradeType)),
+		)
+	}
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               false,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a provisioned cluster with the default value for upgrade_type
+			{
+				Config: provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6, nil).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Explicitly updating the value to MANUAL performs the update
+			{
+				Config: provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6, ptr(client.UPGRADETYPETYPE_MANUAL)).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_MANUAL),
+			},
+			// Removal of the optional value from the config makes no change
+			{
+				Config: provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6, nil).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_MANUAL),
+			},
+			// Change it back to automatic so we can downgrade the cluster to
+			// BASIC.  Currently the ccapi doesn't allow downgrading to BASIC
+			// unless upgrade_type is AUTOMATIC already.
+			{
+				Config: provisionedSingleRegionClusterStep(clusterName, "STANDARD", 6, ptr(client.UPGRADETYPETYPE_AUTOMATIC)).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Downgrade to Basic, the upgrade_type remains AUTOMATIC
+			{
+				Config: onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", nil /* upgradeType */).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Setting the value to MANUAL is not allowed for Basic
+			{
+				Config: onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", ptr(client.UPGRADETYPETYPE_MANUAL)).Config,
+				ExpectError: regexp.MustCompile("plan type BASIC does not allow upgrade_type MANUAL"),
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Setting completely invalid value for upgrade_type
+			{
+				Config: onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", ptr(client.UpgradeTypeType("hi"))).Config,
+				ExpectError: regexp.MustCompile("Attribute serverless.upgrade_type value must be one of"),
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Basic clusters can also accept a value of AUTOMATIC.
+			{
+				Config: onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", ptr(client.UPGRADETYPETYPE_AUTOMATIC)).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
+			// Destroy the cluster so we can create it again in the next step
+			{
+				Config:      " ",
+				Destroy:     true,
+			},
+			// Basic clusters can also be created with a value of AUTOMATIC
+			{
+				Config: onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", ptr(client.UPGRADETYPETYPE_AUTOMATIC)).Config,
+				Check: checkUpgradeTypeResources(client.UPGRADETYPETYPE_AUTOMATIC),
+			},
 		},
 	})
 }
@@ -119,6 +195,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			Config: client.ClusterConfig{
 				Serverless: &client.ServerlessClusterConfig{
 					RoutingId: "routing-id",
+					UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 				},
 			},
 			Regions: []client.Region{
@@ -143,6 +220,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			Plan:             planType,
 			Config: client.ClusterConfig{
 				Serverless: &client.ServerlessClusterConfig{
+					UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					UsageLimits: &client.UsageLimits{
 						RequestUnitLimit: int64Ptr(ruLimit),
 						StorageMibLimit:  int64Ptr(storageLimit),
@@ -168,6 +246,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			Plan:             "STANDARD",
 			Config: client.ClusterConfig{
 				Serverless: &client.ServerlessClusterConfig{
+					UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					UsageLimits: &client.UsageLimits{
 						ProvisionedVcpus: int64Ptr(provisionedVcpus),
 					},
@@ -192,6 +271,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			Plan:             "STANDARD",
 			Config: client.ClusterConfig{
 				Serverless: &client.ServerlessClusterConfig{
+					UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					UsageLimits: &client.UsageLimits{
 						ProvisionedVcpus: int64Ptr(provisionedVcpus),
 					},
@@ -238,7 +318,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 			},
 			initialCluster: singleRegionClusterWithLimits("BASIC", 1_000_000, 1024),
 			updateStep: func() resource.TestStep {
-				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC")
+				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, "BASIC", nil /* upgradeType */)
 			},
 			validateUpdate: func(spec *client.UpdateClusterSpecification) error {
 				// Ensure that provider passes the plan type to Update.
@@ -268,7 +348,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 		{
 			name: "single-region serverless BASIC cluster converted from unlimited resources",
 			createStep: func() resource.TestStep {
-				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType)
+				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType, nil /* upgradeType */)
 			},
 			initialCluster: singleRegionClusterWithUnlimited("BASIC"),
 			updateStep: func() resource.TestStep {
@@ -301,11 +381,11 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 		{
 			name: "single-region serverless BASIC cluster upgraded to STANDARD",
 			createStep: func() resource.TestStep {
-				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType)
+				return onDemandSingleRegionClusterWithUnlimitedStep(clusterName, defaultPlanType, nil /* upgradeType */)
 			},
 			initialCluster: singleRegionClusterWithUnlimited("BASIC"),
 			updateStep: func() resource.TestStep {
-				return provisionedSingleRegionClusterStep(clusterName, "STANDARD", 10)
+				return provisionedSingleRegionClusterStep(clusterName, "STANDARD", 10, nil)
 			},
 			validateUpdate: func(spec *client.UpdateClusterSpecification) error {
 				// Ensure that provider passes the new plan type to Update.
@@ -319,7 +399,7 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 		{
 			name: "single-region serverless STANDARD cluster downgraded to BASIC",
 			createStep: func() resource.TestStep {
-				return provisionedSingleRegionClusterStep(clusterName, defaultPlanType, 10)
+				return provisionedSingleRegionClusterStep(clusterName, defaultPlanType, 10, nil)
 			},
 			initialCluster: provisionedSingleRegionCluster("STANDARD", 10),
 			updateStep: func() resource.TestStep {
@@ -676,12 +756,35 @@ func onDemandSingleRegionClusterWithLimitsStep(
 func onDemandSingleRegionClusterWithUnlimitedStep(
 	clusterName string,
 	planType client.PlanType,
+	upgradeType *client.UpgradeTypeType,
 ) resource.TestStep {
 	var plan string
 	if planType == "" {
 		planType = client.PLANTYPE_BASIC
 	} else {
 		plan = fmt.Sprintf("plan = \"%s\"", planType)
+	}
+
+	testCheckFuncs := []resource.TestCheckFunc{
+		makeDefaultServerlessResourceChecks(clusterName, planType),
+		resource.TestCheckResourceAttr(serverlessResourceName, "serverless.usage_limits.#", "0"),
+		resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.provisioned_vcpus"),
+		resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.request_unit_limit"),
+		resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.storage_mib_limit"),
+		resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.usage_limits.#", "0"),
+		resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.provisioned_vcpus"),
+		resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.request_unit_limit"),
+		resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.storage_mib_limit"),
+	}
+
+	var upgradeTypeConfig string
+	if upgradeType != nil {
+		upgradeTypeConfig = fmt.Sprintf("upgrade_type = \"%s\"", *upgradeType)
+		testCheckFuncs = append(
+			testCheckFuncs,
+			resource.TestCheckResourceAttr(serverlessResourceName, "serverless.upgrade_type", string(*upgradeType)),
+			resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.upgrade_type", string(*upgradeType)),
+		)
 	}
 
 	return resource.TestStep{
@@ -693,6 +796,7 @@ func onDemandSingleRegionClusterWithUnlimitedStep(
 				%s
 				serverless = {
 					usage_limits = {}
+					%s
 				}
 				regions = [{
 					name = "us-central1"
@@ -702,18 +806,8 @@ func onDemandSingleRegionClusterWithUnlimitedStep(
 			data "cockroach_cluster" "test" {
 				id = cockroach_cluster.test.id
 			}
-			`, clusterName, plan),
-		Check: resource.ComposeTestCheckFunc(
-			makeDefaultServerlessResourceChecks(clusterName, planType),
-			resource.TestCheckResourceAttr(serverlessResourceName, "serverless.usage_limits.#", "0"),
-			resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.provisioned_vcpus"),
-			resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.request_unit_limit"),
-			resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.storage_mib_limit"),
-			resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.usage_limits.#", "0"),
-			resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.provisioned_vcpus"),
-			resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.request_unit_limit"),
-			resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.storage_mib_limit"),
-		),
+			`, clusterName, plan, upgradeTypeConfig),
+		Check: resource.ComposeTestCheckFunc(testCheckFuncs...),
 	}
 }
 
@@ -721,7 +815,10 @@ func provisionedSingleRegionClusterStep(
 	clusterName string,
 	planType client.PlanType,
 	provisionedVcpus int,
+	upgradeType *client.UpgradeTypeType,
 ) resource.TestStep {
+	provisionedVcpusStr := strconv.Itoa(provisionedVcpus)
+
 	var plan string
 	if planType == "" {
 		planType = client.PLANTYPE_STANDARD
@@ -729,7 +826,26 @@ func provisionedSingleRegionClusterStep(
 		plan = fmt.Sprintf("plan = \"%s\"", planType)
 	}
 
-	provisionedVcpusStr := strconv.Itoa(provisionedVcpus)
+	testCheckFuncs := []resource.TestCheckFunc{
+		makeDefaultServerlessResourceChecks(clusterName, planType),
+		resource.TestCheckResourceAttr(serverlessResourceName, "serverless.usage_limits.provisioned_vcpus", provisionedVcpusStr),
+		resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.request_unit_limit"),
+		resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.storage_mib_limit"),
+		resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.usage_limits.provisioned_vcpus", provisionedVcpusStr),
+		resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.request_unit_limit"),
+		resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.storage_mib_limit"),
+	}
+
+	var upgradeTypeConfig string
+	if upgradeType != nil {
+		upgradeTypeConfig = fmt.Sprintf("upgrade_type = \"%s\"", *upgradeType)
+		testCheckFuncs = append(
+			testCheckFuncs,
+			resource.TestCheckResourceAttr(serverlessResourceName, "serverless.upgrade_type", string(*upgradeType)),
+			resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.upgrade_type", string(*upgradeType)),
+		)
+	}
+
 	return resource.TestStep{
 		// Serverless cluster with provisioned resources.
 		Config: fmt.Sprintf(`
@@ -741,6 +857,7 @@ func provisionedSingleRegionClusterStep(
 					usage_limits = {
 						provisioned_vcpus = %d
 					}
+					%s
 				}
 				regions = [{
 					name = "us-central1"
@@ -750,16 +867,8 @@ func provisionedSingleRegionClusterStep(
 			data "cockroach_cluster" "test" {
 				id = cockroach_cluster.test.id
 			}
-			`, clusterName, plan, provisionedVcpus),
-		Check: resource.ComposeTestCheckFunc(
-			makeDefaultServerlessResourceChecks(clusterName, planType),
-			resource.TestCheckResourceAttr(serverlessResourceName, "serverless.usage_limits.provisioned_vcpus", provisionedVcpusStr),
-			resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.request_unit_limit"),
-			resource.TestCheckNoResourceAttr(serverlessResourceName, "serverless.usage_limits.storage_mib_limit"),
-			resource.TestCheckResourceAttr(serverlessDataSourceName, "serverless.usage_limits.provisioned_vcpus", provisionedVcpusStr),
-			resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.request_unit_limit"),
-			resource.TestCheckNoResourceAttr(serverlessDataSourceName, "serverless.usage_limits.storage_mib_limit"),
-		),
+			`, clusterName, plan, provisionedVcpus, upgradeTypeConfig),
+		Check: resource.ComposeTestCheckFunc(testCheckFuncs...),
 	}
 }
 

--- a/internal/provider/database_resource_test.go
+++ b/internal/provider/database_resource_test.go
@@ -67,6 +67,7 @@ func TestIntegrationDatabaseResource(t *testing.T) {
 		Config: client.ClusterConfig{
 			Serverless: &client.ServerlessClusterConfig{
 				RoutingId: "routing-id",
+				UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 			},
 		},
 		State: "CREATED",

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -51,6 +51,7 @@ type ServerlessClusterConfig struct {
 	// release.
 	SpendLimit  types.Int64  `tfsdk:"spend_limit"`
 	RoutingId   types.String `tfsdk:"routing_id"`
+	UpgradeType types.String `tfsdk:"upgrade_type"`
 	UsageLimits *UsageLimits `tfsdk:"usage_limits"`
 }
 

--- a/internal/provider/private_endpoint_connection_resource_test.go
+++ b/internal/provider/private_endpoint_connection_resource_test.go
@@ -118,6 +118,7 @@ func TestIntegrationPrivateEndpointConnectionResource(t *testing.T) {
 				Config: client.ClusterConfig{
 					Serverless: &client.ServerlessClusterConfig{
 						RoutingId: "routing-id",
+						UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					},
 				},
 				Regions: []client.Region{

--- a/internal/provider/private_endpoint_services_resource_test.go
+++ b/internal/provider/private_endpoint_services_resource_test.go
@@ -120,6 +120,7 @@ func TestIntegrationPrivateEndpointServicesResource(t *testing.T) {
 				Config: client.ClusterConfig{
 					Serverless: &client.ServerlessClusterConfig{
 						RoutingId: "routing-id",
+						UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 					},
 				},
 				Regions: []client.Region{

--- a/internal/provider/sql_user_resource_test.go
+++ b/internal/provider/sql_user_resource_test.go
@@ -70,6 +70,7 @@ func TestIntegrationSqlUserResource(t *testing.T) {
 		Config: client.ClusterConfig{
 			Serverless: &client.ServerlessClusterConfig{
 				RoutingId: "routing-id",
+				UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
 			},
 		},
 		State: "CREATED",


### PR DESCRIPTION
upgrade_type is now added for BASIC and STANDARD clusters.  It can be used to dictate how the cluster handles major version upgrades.  Valid values for upgrade_type are AUTOMATIC and MANUAL.  BASIC clusters support only AUTOMATIC upgrades.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
