### PR TITLE
update docs for cluster_resource upgrade_type

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -79,7 +79,7 @@ Read-Only:
 
 - `routing_id` (String) Cluster identifier in a connection string.
 - `spend_limit` (Number, Deprecated) Spend limit in US cents.
-- `upgrade_type` (String) Dictates the behavior of cockroach major version upgrades.
+- `upgrade_type` (String) Dictates the behavior of CockroachDB major version upgrades.
 - `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))
 
 <a id="nestedatt--serverless--usage_limits"></a>

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -133,7 +133,7 @@ Read-Only:
 Optional:
 
 - `spend_limit` (Number, Deprecated) Spend limit in US cents.
-- `upgrade_type` (String) Dictates the behavior of cockroach major version upgrades. If plan type is 'BASIC', this attribute must be left empty or set to 'AUTOMATIC'. Allowed values are: 
+- `upgrade_type` (String) Dictates the behavior of CockroachDB major version upgrades. Manual upgrades are not supported on CockroachDB Basic. Manual or automatic upgrades are supported on CockroachDB Standard. If you omit the field, it defaults to `AUTOMATIC`. Allowed values are:
   * MANUAL
   * AUTOMATIC
 - `usage_limits` (Attributes) (see [below for nested schema](#nestedatt--serverless--usage_limits))

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -91,7 +91,7 @@ func (d *clusterDataSource) Schema(
 					},
 					"upgrade_type": schema.StringAttribute{
 						Computed:    true,
-						Description: "Dictates the behavior of cockroach major version upgrades.",
+						Description: "Dictates the behavior of CockroachDB major version upgrades.",
 					},
 				},
 			},

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -194,7 +194,7 @@ func (r *clusterResource) Schema(
 							stringplanmodifier.UseStateForUnknown(),
 						},
 						Validators:  []validator.String{stringvalidator.OneOf(AllowedUpgradeTypeTypeEnumValueStrings...)},
-						MarkdownDescription: "Dictates the behavior of cockroach major version upgrades. If plan type is 'BASIC', this attribute must be left empty or set to 'AUTOMATIC'. Allowed values are: " +
+						MarkdownDescription: "Dictates the behavior of CockroachDB major version upgrades. Manual upgrades are not supported on CockroachDB Basic. Manual or automatic upgrades are supported on CockroachDB Standard. If you omit the field, it defaults to `AUTOMATIC`. Allowed values are:" +
 							formatEnumMarkdownList(AllowedUpgradeTypeTypeEnumValueStrings),
 					},
 				},


### PR DESCRIPTION
Note that the upgrade_type docs in the cluster data source were not updated as part of this change and remain:

"Dictates the behavior of cockroach major version upgrades."

The reason for this is that the remainder that was added seemed only to pertain to setting the values and not for reading them back.