### PR TITLE
Added missing import.sh files and generate docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- Added missing import.sh files so resource docs indicating supporting of
+  Import are clear.
+
 ## Changed
 
 - Allow removal (deletion) of locked clusters.  The api now supports deletion

--- a/docs/resources/client_ca_cert.md
+++ b/docs/resources/client_ca_cert.md
@@ -47,3 +47,12 @@ resource "cockroach_client_ca_cert" "prod" {
 ### Read-Only
 
 - `status` (String) Status of client CA certs on a cluster.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_client_ca_cert.prod 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -172,3 +172,12 @@ Optional:
 - `provisioned_virtual_cpus` (Number) Maximum number of vCPUs that the cluster can use.
 - `request_unit_limit` (Number) Maximum number of Request Units that the cluster can consume during the month.
 - `storage_mib_limit` (Number) Maximum amount of storage (in MiB) that the cluster can have at any time during the month.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_cluster.my_cluster 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -13,8 +13,8 @@ Customer-managed encryption keys (CMEK) resource for a single cluster.
 ## Example Usage
 
 ```terraform
-resource "cockroach_cmek" "dedicated" {
-  id = cockroach_cluster.dedicated.id
+resource "cockroach_cmek" "advanced" {
+  id = cockroach_cluster.advanced.id
   regions = [{
     region : "us-central-1"
     key : {
@@ -89,3 +89,12 @@ Read-Only:
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_cmek.advanced 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -35,3 +35,12 @@ resource "cockroach_folder" "a_team_dev" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <folder id>
+terraform import cockroach_folder.my_folder 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/jwt_issuer.md
+++ b/docs/resources/jwt_issuer.md
@@ -56,3 +56,15 @@ Required:
 
 - `cc_identity` (String) Specifies how to map the fetched token identity to an identity in CockroachDB Cloud. In case of a regular expression for token_identity, this must contain a \1 placeholder for the matched content. Note that you will need to escape the backslash in the string as in the example usage (\\\1).
 - `token_identity` (String) Specifies how to fetch external identity from the token claim. A regular expression must start with a forward slash. The regular expression must be in RE2 compatible syntax. For further details, please see https://github.com/google/re2/wiki/Syntax.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# JWT Issuer ID can be found by running a GET against the Cockroach Cloud API to
+# list all existing JWT issuers.
+# https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/jwt-issuers
+# format: <jwt issuer id>
+terraform import cockroach_jwt_issuer.my_issuer 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/log_export_config.md
+++ b/docs/resources/log_export_config.md
@@ -82,3 +82,12 @@ Optional:
 
 - `min_level` (String) The minimum log level to filter to this log group.
 - `redact` (Boolean) Governs whether this log group should aggregate redacted logs if unset.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_log_export_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -44,3 +44,12 @@ resource "cockroach_maintenance_window" "example" {
 - `id` (String) Cluster ID.
 - `offset_duration` (Number) Duration in seconds from the beginning of each Monday (UTC) after which the maintenance window starts.
 - `window_duration` (Number) Duration in seconds that the maintenance window will remain active for after it starts.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_maintenance_window.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/metric_export_cloudwatch_config.md
+++ b/docs/resources/metric_export_cloudwatch_config.md
@@ -56,3 +56,12 @@ resource "cockroach_metric_export_cloudwatch_config" "example" {
 
 - `status` (String) Encodes the possible states that a metric export configuration can be in as it is created, deployed, and disabled.
 - `user_message` (String) Elaborates on the metric export status and hints at how to fix issues that may have occurred during asynchronous operations.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_metric_export_cloudwatch_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/metric_export_datadog_config.md
+++ b/docs/resources/metric_export_datadog_config.md
@@ -48,3 +48,12 @@ resource "cockroach_metric_export_datadog_config" "example" {
 
 - `status` (String) Encodes the possible states that a metric export configuration can be in as it is created, deployed, and disabled.
 - `user_message` (String) Elaborates on the metric export status and hints at how to fix issues that may have occurred during asynchronous operations.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_metric_export_datadog_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/metric_export_prometheus_config.md
+++ b/docs/resources/metric_export_prometheus_config.md
@@ -33,3 +33,12 @@ resource "cockroach_metric_export_prometheus_config" "example" {
 
 - `status` (String) The current state of the metric export configuration.  Possible values are: [`NOT_DEPLOYED` `DISABLING` `ENABLING` `ENABLED` `ERROR`]
 - `targets` (Map of String) Represents prometheus scrape endpoint for each region. You can fetch endpoints either by executing `terraform state show {resource}` or by enabling terraform logs.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_metric_export_prometheus_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/docs/resources/version_deferral.md
+++ b/docs/resources/version_deferral.md
@@ -36,3 +36,12 @@ resource "cockroach_version_deferral" "example" {
 
 - `deferral_policy` (String) The policy for managing automated minor version upgrades. Set to FIXED_DEFERRAL to defer upgrades by 60 days or NOT_DEFERRED to apply upgrades immediately.
 - `id` (String) Cluster ID.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+# format: <cluster id>
+terraform import cockroach_version_deferral.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d
+```

--- a/examples/resources/cockroach_aws_private_endpoint_connection/resource.tf
+++ b/examples/resources/cockroach_aws_private_endpoint_connection/resource.tf
@@ -1,9 +1,0 @@
-variable "cluster_id" {
-  type        = string
-  description = "the id for the CockroachDB Cloud cluster"
-}
-
-resource "cockroach_private_endpoint_connection" "cockroach" {
-  cluster_id  = var.cluster_id
-  endpoint_id = "the endpoint id assigned by cloud provider to the client-side of the connection"
-}

--- a/examples/resources/cockroach_client_ca_cert/import.sh
+++ b/examples/resources/cockroach_client_ca_cert/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_client_ca_cert.prod 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_cluster/import.sh
+++ b/examples/resources/cockroach_cluster/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_cluster.my_cluster 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_cmek/import.sh
+++ b/examples/resources/cockroach_cmek/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_cmek.advanced 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_cmek/resource.tf
+++ b/examples/resources/cockroach_cmek/resource.tf
@@ -1,5 +1,5 @@
-resource "cockroach_cmek" "dedicated" {
-  id = cockroach_cluster.dedicated.id
+resource "cockroach_cmek" "advanced" {
+  id = cockroach_cluster.advanced.id
   regions = [{
     region : "us-central-1"
     key : {

--- a/examples/resources/cockroach_folder/import.sh
+++ b/examples/resources/cockroach_folder/import.sh
@@ -1,0 +1,2 @@
+# format: <folder id>
+terraform import cockroach_folder.my_folder 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_jwt_issuer/import.sh
+++ b/examples/resources/cockroach_jwt_issuer/import.sh
@@ -1,0 +1,5 @@
+# JWT Issuer ID can be found by running a GET against the Cockroach Cloud API to
+# list all existing JWT issuers.
+# https://www.cockroachlabs.com/docs/api/cloud/v1#get-/api/v1/jwt-issuers
+# format: <jwt issuer id>
+terraform import cockroach_jwt_issuer.my_issuer 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_log_export_config/import.sh
+++ b/examples/resources/cockroach_log_export_config/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_log_export_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_maintenance_window/import.sh
+++ b/examples/resources/cockroach_maintenance_window/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_maintenance_window.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_metric_export_cloudwatch_config/import.sh
+++ b/examples/resources/cockroach_metric_export_cloudwatch_config/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_metric_export_cloudwatch_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_metric_export_datadog_config/import.sh
+++ b/examples/resources/cockroach_metric_export_datadog_config/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_metric_export_datadog_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_metric_export_prometheus_config/import.sh
+++ b/examples/resources/cockroach_metric_export_prometheus_config/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_metric_export_prometheus_config.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d

--- a/examples/resources/cockroach_version_deferral/import.sh
+++ b/examples/resources/cockroach_version_deferral/import.sh
@@ -1,0 +1,2 @@
+# format: <cluster id>
+terraform import cockroach_version_deferral.example 1f69fdd2-600a-4cfc-a9ba-16995df0d77d


### PR DESCRIPTION
The docs plugin adds a section to each each resource indicating the support of Import based on the existence of an import.sh example. This file was missing for some resources despite the actual support of the Import action. The missing files are added here and docs are regenerated.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
