### PR TITLE
[CC-30294] don't wait for lock before cluster deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Changed
+
+- Allow removal (deletion) of locked clusters.  The api now supports deletion
+  of locked clusters so we remove the wait prior to following through with the
+  deletion.
+
 ### Added
 
 - Management of cluster backup settings is now supported using the

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -1074,11 +1074,6 @@ func (r *clusterResource) Delete(
 		return
 	}
 
-	waitForClusterLock(ctx, state, r.provider.service, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
 	// Get cluster ID from state
 	if !IsKnown(state.ID) {
 		return


### PR DESCRIPTION
Previously the api didn't allow deletion of locked clusters.  It now does so waiting for the lock before deleting is just adding extra time to apply the changes.  We now issue the delete right away.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
