### PR TITLE
[CC-30315] rely on cluster api for validating parent_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Remove unnecessary api call to Folders endpoint to manually validate
+  `cockroach_cluster.parent_id`.
+
 - Allow removal (deletion) of locked clusters.  The api now supports deletion
   of locked clusters so we remove the wait prior to following through with the
   deletion.

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -482,16 +482,6 @@ func (r *clusterResource) Create(
 
 	if IsKnown(plan.ParentId) {
 		parentID := plan.ParentId.ValueString()
-		if parentID != "root" {
-			traceAPICall("GetFolder")
-			_, _, err := r.provider.service.GetFolder(ctx, parentID)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"Error getting the parent folder",
-					fmt.Sprintf("Could not get the parent folder: %s", formatAPIErrorMessage(err)))
-				return
-			}
-		}
 		clusterSpec.SetParentId(parentID)
 	}
 
@@ -956,16 +946,6 @@ func (r *clusterResource) Update(
 	// Parent Id
 	if IsKnown(plan.ParentId) {
 		parentID := plan.ParentId.ValueString()
-		if parentID != "root" {
-			traceAPICall("GetFolder")
-			_, _, err := r.provider.service.GetFolder(ctx, parentID)
-			if err != nil {
-				resp.Diagnostics.AddError(
-					"Error getting the parent folder",
-					fmt.Sprintf("Could not get the parent folder: %s", formatAPIErrorMessage(err)))
-				return
-			}
-		}
 		clusterReq.SetParentId(parentID)
 	}
 


### PR DESCRIPTION
Previously, the cluster create and update operations would validate the parent_id manually via a separate API call.  This validation is also done within the create and update api calls so these additional calls were unnecessary.  We remove them here and add tests around setting this value which were previously missing.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
