### PR TITLE
Add a github action for triggering acceptance tests

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,20 @@
+name: Manually Run Acceptance Tests
+on: workflow_dispatch
+jobs:
+  acceptance-test:
+    name: acceptance-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Tests
+        run: make testacc
+        env:
+          COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}


### PR DESCRIPTION
This action is very similar to the pre-release-ci action which runs when a tag is created, but it can be triggered manually on any branch. This allow us to easily run the acceptance tests in other convenient times such as before landing a branch or before creating a tag.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
