### PR TITLE
[CC-30640] allow manual version control for standard clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.0] - 2024-12-05
+
+### Added
+
+- Added support for manual version control of Standard tier clusters.
+
 ## [1.10.0] - 2024-11-15
 
 ### Fixed

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -88,7 +88,7 @@ resource "cockroach_cluster" "basic" {
 
 - `backup_config` (Attributes) The backup settings for a cluster.
  Each cluster has backup settings that determine if backups are enabled, how frequently they are taken, and how long they are retained for. Use this attribute to manage those settings. (see [below for nested schema](#nestedatt--backup_config))
-- `cockroach_version` (String) Major version of CockroachDB running on the cluster.
+- `cockroach_version` (String) Major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL').
 - `dedicated` (Attributes) (see [below for nested schema](#nestedatt--dedicated))
 - `delete_protection` (Boolean) Set to true to enable delete protection on the cluster. If unset, the server chooses the value on cluster creation, and preserves the value on cluster update.
 - `parent_id` (String) The ID of the cluster's parent folder. 'root' is used for a cluster at the root level.


### PR DESCRIPTION
STANDARD clusters now accept the cockroach_version attribute on cluster update for manual upgrades control.  The serverless.upgrade_type attribute must be set to MANUAL.

As part of this an API call to validate cockraoch_version for ADVANCED clusters prior to the update was removed.  This logic provided some nicer error messages for advanced clusters but the logic was complex, it required an additional api call to fetch the valid versions and standard tier version checking is not supported.  We now rely on the serverside validation for checking versions.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
