### PR TITLE
[CC-30770] document maintenance windows are Advanced only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disallow 0 from being passed for disk_iops and update the docs to indicate
+- Update docs to reflect that maintenance windows are for Advanced clusters
+  only.
+
+- Disallow 0 from being passed for `disk_iops` and update the docs to indicate
   that omitting the attribute is the correct way to get the default behavior.
 
 - Validate that `node_count` is not passed in with serverless cluster regions.

--- a/docs/resources/maintenance_window.md
+++ b/docs/resources/maintenance_window.md
@@ -3,12 +3,12 @@
 page_title: "cockroach_maintenance_window Resource - terraform-provider-cockroach"
 subcategory: ""
 description: |-
-  Maintenance window configuration for a cluster.
+  Maintenance window configuration for a cluster. Maintenance Windows are supported for Advanced clusters only.
 ---
 
 # cockroach_maintenance_window (Resource)
 
-Maintenance window configuration for a cluster.
+Maintenance window configuration for a cluster. Maintenance Windows are supported for Advanced clusters only.
 
 ## Example Usage
 

--- a/internal/provider/maintenance_window.go
+++ b/internal/provider/maintenance_window.go
@@ -55,7 +55,7 @@ func (r *maintenanceWindowResource) Schema(
 	_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse,
 ) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Maintenance window configuration for a cluster.",
+		MarkdownDescription: "Maintenance window configuration for a cluster. Maintenance Windows are supported for Advanced clusters only.",
 		Attributes:          maintenanceWindowAttributes,
 	}
 }
@@ -190,7 +190,7 @@ func (r *maintenanceWindowResource) setMaintenanceWindow(
 	if err != nil {
 		diags.AddError(
 			"Error setting maintenance window",
-			fmt.Sprintf("Could not set maintenance window: %v", formatAPIErrorMessage(err)),
+			formatAPIErrorMessage(err),
 		)
 		return
 	}
@@ -218,7 +218,7 @@ func (r *maintenanceWindowResource) Delete(
 		} else {
 			resp.Diagnostics.AddError(
 				"Error deleting maintenance window",
-				fmt.Sprintf("Could not delete maintenance window: %v", formatAPIErrorMessage(err)),
+				formatAPIErrorMessage(err),
 			)
 		}
 		return


### PR DESCRIPTION
Previously there was no indication that maintenance windows are not supported for Basic or Standard clusters.  We update the documentation here to reflect that and add a test showing that attempting to use maintentance windows with a non-Advanced cluster will fail.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
