### PR TITLE
[CC-30768] don't allow node_count for serverless cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.11.0] - 2024-12-05
+### Fixed
+
+- Validate that `node_count` is not passed in with serverless cluster regions.
+  Also, clear up in the documentation that this is not allowed.
 
 ### Added
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -113,7 +113,7 @@ Required:
 
 Optional:
 
-- `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
+- `node_count` (Number) Number of nodes in the region. Valid for Advanced clusters only.
 - `primary` (Boolean) Set to true to mark this region as the primary for a serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.
 
 Read-Only:

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -81,7 +81,7 @@ Required:
 
 Optional:
 
-- `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
+- `node_count` (Number) Number of nodes in the region. Valid for Advanced clusters only.
 - `primary` (Boolean) Set to true to mark this region as the primary for a serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.
 
 Read-Only:

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -827,6 +827,30 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 		ignoreImportPaths []string
 	}{
 		{
+			name: "STANDARD clusters must not have a node_count",
+			createStep: func() resource.TestStep {
+				return resource.TestStep{
+					Config: fmt.Sprintf(`
+						resource "cockroach_cluster" "test" {
+							name           = "%s"
+							cloud_provider = "GCP"
+							serverless = {}
+							regions = [
+								{
+									name = "us-central1"
+								},
+								{
+									name = "us-central1"
+									node_count = 1
+								},
+							]
+						}
+					`, clusterName),
+					ExpectError: regexp.MustCompile("node_count is supported for ADVANCED clusters only"),
+				}
+			},
+		},
+		{
 			name: "single-region serverless BASIC cluster converted to unlimited resources",
 			createStep: func() resource.TestStep {
 				return onDemandSingleRegionClusterWithLimitsStep(clusterName, "BASIC", 1_000_000, 1024)


### PR DESCRIPTION
Previously it was possible to pass in the node_count value for serverless region because the type is shared with dedicated clusters. This ended up causing a state inconsistency however becase node_count is coerced to 0 by the api which conflicts with a value added in the config. To solve this, we simply validate that node_count is not used unless cluster plan is Advanced.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
