### PR TITLE
[CC-30769] remove machine_type from examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Changed
+
+- Remove `machine_type` from examples and clear up in docs that this field
+  requires a feature flag and is not recommended for use.
+
 ### Fixed
 
 - Update docs to reflect that maintenance windows are for Advanced clusters

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -18,8 +18,8 @@ resource "cockroach_cluster" "advanced" {
   cloud_provider = "GCP"
   plan           = "ADVANCED"
   dedicated = {
-    storage_gib  = 15
-    machine_type = "n2-standard-4"
+    storage_gib      = 15
+    num_virtual_cpus = 4
   }
   regions = [
     {
@@ -140,7 +140,7 @@ Optional:
 
 - `cidr_range` (String) The IPv4 range in CIDR format that will be used by the cluster. This is supported only on GCP, and must have a subnet mask no larger than /19. Defaults to "172.28.0.0/14". This cannot be changed after cluster creation.
 - `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. Omitting this attribute will result in the cloud provider-specific default.
-- `machine_type` (String) Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4.
+- `machine_type` (String) Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4. This attribute requires a feature flag to be enabled. It is recommended to leave this empty and use `num_virtual_cpus` to control the machine type.
 - `num_virtual_cpus` (Number) Number of virtual CPUs per node in the cluster.
 - `private_network_visibility` (Boolean) Set to true to assign private IP addresses to nodes. Required for CMEK and other advanced networking features. Clusters created with this flag will have advanced security features enabled.  This cannot be changed after cluster creation and incurs additional charges.  See [Create an Advanced Cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-an-advanced-cluster.html#step-6-configure-advanced-security-features) and [Pricing](https://www.cockroachlabs.com/pricing/) for more information.
 - `storage_gib` (Number) Storage amount per node in GiB.

--- a/examples/resources/cockroach_cluster/resource.tf
+++ b/examples/resources/cockroach_cluster/resource.tf
@@ -3,8 +3,8 @@ resource "cockroach_cluster" "advanced" {
   cloud_provider = "GCP"
   plan           = "ADVANCED"
   dedicated = {
-    storage_gib  = 15
-    machine_type = "n2-standard-4"
+    storage_gib      = 15
+    num_virtual_cpus = 4
   }
   regions = [
     {

--- a/examples/workflows/aws_privatelink/main.tf
+++ b/examples/workflows/aws_privatelink/main.tf
@@ -37,10 +37,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "m5.large"
+  default  = 4
 }
 
 variable "subnets" {
@@ -88,8 +88,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = "AWS"
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [{
     name       = var.aws_region

--- a/examples/workflows/cockroach_client_ca_cert/main.tf
+++ b/examples/workflows/cockroach_client_ca_cert/main.tf
@@ -27,10 +27,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "n2-standard-2"
+  default  = 4
 }
 
 terraform {
@@ -48,8 +48,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = var.cloud_provider
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [
     for r in var.cloud_provider_regions : {

--- a/examples/workflows/cockroach_cmek/aws/main.tf
+++ b/examples/workflows/cockroach_cmek/aws/main.tf
@@ -32,10 +32,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "m5.large"
+  default  = 4
 }
 
 terraform {
@@ -69,7 +69,7 @@ resource "cockroach_cluster" "example" {
   cloud_provider = "AWS"
   dedicated = {
     storage_gib                = var.storage_gib
-    machine_type               = var.machine_type
+    num_virtual_cpus           = var.vcpu_count
     private_network_visibility = true
   }
   regions = [{

--- a/examples/workflows/cockroach_cmek/gcp/main.tf
+++ b/examples/workflows/cockroach_cmek/gcp/main.tf
@@ -37,10 +37,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "n2-standard-2"
+  default  = 4
 }
 
 terraform {
@@ -74,7 +74,7 @@ resource "cockroach_cluster" "example" {
   cloud_provider = "GCP"
   dedicated = {
     storage_gib                = var.storage_gib
-    machine_type               = var.machine_type
+    num_virtual_cpus           = var.vcpu_count
     private_network_visibility = true
   }
   regions = [{

--- a/examples/workflows/cockroach_log_export_config/aws_cockroach_log_export_config/main.tf
+++ b/examples/workflows/cockroach_log_export_config/aws_cockroach_log_export_config/main.tf
@@ -28,10 +28,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "m5.large"
+  default  = 4
 }
 
 variable "iam_role_name" {
@@ -83,8 +83,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = "AWS"
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [{
     name       = var.aws_region,

--- a/examples/workflows/cockroach_log_export_config/gcp_cockroach_log_export_config/main.tf
+++ b/examples/workflows/cockroach_log_export_config/gcp_cockroach_log_export_config/main.tf
@@ -26,10 +26,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "n2-standard-2"
+  default  = 4
 }
 
 variable "iam_role_id" {
@@ -77,8 +77,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = "GCP"
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [{
     name       = var.gcp_region,

--- a/examples/workflows/cockroach_metric_export/aws/main.tf
+++ b/examples/workflows/cockroach_metric_export/aws/main.tf
@@ -28,10 +28,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "m5.large"
+  default  = 4
 }
 
 variable "iam_role_name" {
@@ -95,8 +95,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = "AWS"
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [{
     name       = var.aws_region,

--- a/examples/workflows/cockroach_metric_export/gcp/main.tf
+++ b/examples/workflows/cockroach_metric_export/gcp/main.tf
@@ -15,10 +15,10 @@ variable "storage_gib" {
   default  = 15
 }
 
-variable "machine_type" {
-  type     = string
+variable "vcpu_count" {
+  type     = number
   nullable = false
-  default  = "n2-standard-2"
+  default  = 4
 }
 
 variable "gcp_region" {
@@ -55,8 +55,8 @@ resource "cockroach_cluster" "example" {
   name           = var.cluster_name
   cloud_provider = "GCP"
   dedicated = {
-    storage_gib  = var.storage_gib
-    machine_type = var.machine_type
+    storage_gib      = var.storage_gib
+    num_virtual_cpus = var.vcpu_count
   }
   regions = [{
     name       = var.gcp_region,

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -234,7 +234,7 @@ func (r *clusterResource) Schema(
 					"machine_type": schema.StringAttribute{
 						Optional:    true,
 						Computed:    true,
-						Description: "Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4.",
+						MarkdownDescription: "Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4. This attribute requires a feature flag to be enabled. It is recommended to leave this empty and use `num_virtual_cpus` to control the machine type.",
 					},
 					"num_virtual_cpus": schema.Int64Attribute{
 						Optional:    true,


### PR DESCRIPTION
machine_type is not recommended for usage so we remove it from the examples and replace it with num_virtual_cpus instead.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [x] Example(s)
