### PR TITLE
CC-30971: update state with allowlist api responses

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,6 +14,11 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      # We don't pin the version of terraform to ensure the tests run against
+      # the latest CLI version.
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Tests
         run: make testacc
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,11 @@ jobs:
         with:
           go-version: 1.22
 
+      # We don't pin the version of terraform to ensure the tests run against
+      # the latest CLI version.
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Tests
         run: make test
 
@@ -71,6 +76,13 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+
+      # Terraform fmt is run on the docs directory, don't bother pinning this
+      # version.  This will install the latest version. If there is a difference
+      # in format between the latest version and the local version, the
+      # developer should update.
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
 
       - name: Build docs
         run: make generate

--- a/.github/workflows/pre-release-ci.yaml
+++ b/.github/workflows/pre-release-ci.yaml
@@ -19,6 +19,11 @@ jobs:
         with:
           go-version: 1.22
 
+      # We don't pin the version of terraform to ensure the tests run against
+      # the latest CLI version.
+      - name: Install terraform
+        uses: hashicorp/setup-terraform@v3
+
       - name: Tests
         run: make testacc
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Fixed
+
+- Fix a state consistency error that occurred when an allowlist was created
+  without a name.
+
 ## [1.11.0] - 2024-12-09
 
 ### Changed

--- a/docs/resources/allow_list.md
+++ b/docs/resources/allow_list.md
@@ -36,7 +36,7 @@ resource "cockroach_allow_list" "vpn" {
 
 ### Optional
 
-- `name` (String) Name of this allowlist entry. If not set explicitly, this value does not sync with the server.
+- `name` (String) Name of this allowlist entry. If left unset, it will inherit a server-side default.
 
 ### Read-Only
 


### PR DESCRIPTION
Previously the object the api returned for created and updated allowlist entries was ignored when updating the terraform state.  This meant that defaults set on the server side and returned were not correctly being set and could cause state inconsistencies in case they were different. Specifically there was a case where not setting an initial value for the create would return an empty string.  The empty string caused a state consistency error with the unset value.
To fix this we now set the state based on the response.  Also, part of this the code was reworked to be more similar to how other resources are structured.

Tests were added to show that creating an allowlist without a name now succeeds.

Also, as part of this change, instances of allowList were renamed to allowlist for consistency.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
