### PR TITLE
add name back to allowlist creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.11.2] - 2025-02-07
+
+### Fixed
+
+- Add name back to allowlist creations.
+
 ## [1.11.1] - 2025-01-16
 
 ### Fixed


### PR DESCRIPTION
In a previous commit (272cdd80b3f93b61facaffa39a886dcd368980d9), passing the allowlist name during creation of that resource was mistakenly removed.  The test excersing it was also changed such that it didn't catch that issue.  We now add back the name and augment the test so that it covers this case again.

closes #263

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
