### PR TITLE
[CC-30705] add labels attribute to cluster and folder resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.0] - 2025-04-30
+
 ### Added
+
+- Added support for label management in the `cockroach_cluster` and
+  `cockroach_folder` resources.
 
 - Added `full_version` attribute to the cluster data source and resource for
   fetching the full version string. (e.g. v25.1.0)

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -39,6 +39,7 @@ data "cockroach_cluster" "cockroach" {
 - `delete_protection` (Boolean) Set to true to enable delete protection on the cluster.
 - `full_version` (String) The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)
 - `id` (String) The ID of this resource.
+- `labels` (Map of String) Map of key-value pairs used to organize and categorize resources.
 - `name` (String) Name of the cluster.
 - `operation_status` (String) Describes the current long-running operation, if any.
 - `parent_id` (String) The ID of the cluster's parent folder. 'root' is used for a cluster at the root level.

--- a/docs/data-sources/folder.md
+++ b/docs/data-sources/folder.md
@@ -36,5 +36,6 @@ data "cockroach_folder" "prod" {
 
 ### Read-Only
 
+- `labels` (Map of String) Map of key-value pairs used to organize and categorize resources.
 - `name` (String) Name of the folder.
 - `parent_id` (String) The ID of the folders's parent folder. 'root' is used for a folder at the root level.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -33,6 +33,10 @@ resource "cockroach_cluster" "advanced" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 resource "cockroach_cluster" "standard" {
@@ -56,6 +60,10 @@ resource "cockroach_cluster" "standard" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "hr-1234"
+  }
 }
 
 resource "cockroach_cluster" "basic" {
@@ -69,6 +77,10 @@ resource "cockroach_cluster" "basic" {
     }
   ]
   delete_protection = false
+  labels = {
+    environment   = "staging",
+    "cost-center" = "mkt-1234"
+  }
 }
 ```
 
@@ -91,6 +103,7 @@ resource "cockroach_cluster" "basic" {
 - `cockroach_version` (String) The major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL'). (e.g. v25.0)
 - `dedicated` (Attributes) (see [below for nested schema](#nestedatt--dedicated))
 - `delete_protection` (Boolean) Set to true to enable delete protection on the cluster. If unset, the server chooses the value on cluster creation, and preserves the value on cluster update.
+- `labels` (Map of String) Map of key-value pairs used to organize and categorize resources. If unset, labels will not be managed by Terraform. If set, labels defined in Terraform will overwrite any labels configured outside this platform.
 - `parent_id` (String) The ID of the cluster's parent folder. 'root' is used for a cluster at the root level.
 - `plan` (String) Denotes cluster plan type: 'BASIC' or 'STANDARD' or 'ADVANCED'.
 - `serverless` (Attributes) (see [below for nested schema](#nestedatt--serverless))

--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -16,11 +16,19 @@ CockroachDB Cloud folder.
 resource "cockroach_folder" "a_team" {
   name      = "a-team"
   parent_id = "root"
+  labels = {
+    environment   = "staging",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 resource "cockroach_folder" "a_team_dev" {
   name      = "dev"
   parent_id = cockroach_folder.a_team.id
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-5678"
+  }
 }
 ```
 
@@ -31,6 +39,10 @@ resource "cockroach_folder" "a_team_dev" {
 
 - `name` (String) Name of the folder.
 - `parent_id` (String) ID of the parent folder. Use 'root' for the root level (no parent folder).
+
+### Optional
+
+- `labels` (Map of String) Map of key-value pairs used to organize and categorize resources. If unset, labels will not be managed by Terraform. If set, labels defined in Terraform will overwrite any labels configured outside this platform.
 
 ### Read-Only
 

--- a/examples/resources/cockroach_cluster/resource.tf
+++ b/examples/resources/cockroach_cluster/resource.tf
@@ -18,6 +18,10 @@ resource "cockroach_cluster" "advanced" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 resource "cockroach_cluster" "standard" {
@@ -41,6 +45,10 @@ resource "cockroach_cluster" "standard" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "hr-1234"
+  }
 }
 
 resource "cockroach_cluster" "basic" {
@@ -54,4 +62,8 @@ resource "cockroach_cluster" "basic" {
     }
   ]
   delete_protection = false
+  labels = {
+    environment   = "staging",
+    "cost-center" = "mkt-1234"
+  }
 }

--- a/examples/resources/cockroach_folder/resource.tf
+++ b/examples/resources/cockroach_folder/resource.tf
@@ -1,9 +1,17 @@
 resource "cockroach_folder" "a_team" {
   name      = "a-team"
   parent_id = "root"
+  labels = {
+    environment   = "staging",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 resource "cockroach_folder" "a_team_dev" {
   name      = "dev"
   parent_id = cockroach_folder.a_team.id
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-5678"
+  }
 }

--- a/examples/workflows/cockroach_advanced_cluster/main.tf
+++ b/examples/workflows/cockroach_advanced_cluster/main.tf
@@ -111,6 +111,10 @@ resource "cockroach_cluster" "example" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 data "cockroach_cluster_cert" "example" {

--- a/examples/workflows/cockroach_basic_cluster/main.tf
+++ b/examples/workflows/cockroach_basic_cluster/main.tf
@@ -48,6 +48,10 @@ resource "cockroach_cluster" "example" {
   plan           = "BASIC"
   serverless     = {}
   regions        = [for r in var.cloud_provider_regions : { name = r }]
+  labels = {
+    environment   = "staging",
+    "cost-center" = "mkt-1234"
+  }
 }
 
 resource "cockroach_sql_user" "example" {

--- a/examples/workflows/cockroach_folder/main.tf
+++ b/examples/workflows/cockroach_folder/main.tf
@@ -45,11 +45,19 @@ provider "cockroach" {
 resource "cockroach_folder" "example_folder_parent" {
   name      = var.folder_parent_name
   parent_id = "root"
+  labels = {
+    environment   = "production",
+    "cost-center" = "eng-1234"
+  }
 }
 
 resource "cockroach_folder" "example_folder_child" {
   name      = var.folder_child_name
   parent_id = cockroach_folder.example_folder_parent.id
+  labels = {
+    campaign   = "987654",
+    managed_by = "jane_doe"
+  }
 }
 
 resource "cockroach_user_role_grant" "folder_admin_grant" {

--- a/examples/workflows/cockroach_standard_cluster/main.tf
+++ b/examples/workflows/cockroach_standard_cluster/main.tf
@@ -70,6 +70,10 @@ resource "cockroach_cluster" "example" {
     frequency_minutes = 60
     retention_days    = 30
   }
+  labels = {
+    environment   = "production",
+    "cost-center" = "mkt-5678"
+  }
 }
 
 resource "cockroach_sql_user" "example" {

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type clusterDataSource struct {
@@ -204,6 +205,11 @@ func (d *clusterDataSource) Schema(
 					},
 				},
 			},
+			"labels": schema.MapAttribute{
+				Computed:    true,
+				ElementType: types.StringType,
+				Description: "Map of key-value pairs used to organize and categorize resources.",
+			},
 		},
 	}
 }
@@ -288,7 +294,7 @@ func (d *clusterDataSource) Read(
 	// The concept of a plan doesn't apply to data sources.
 	// Using a nil plan means we won't try to re-sort the region list.
 	var newState CockroachCluster
-	loadClusterToTerraformState(cockroachCluster, remoteBackupConfig, &newState, nil)
+	loadClusterToTerraformState(ctx, cockroachCluster, remoteBackupConfig, &newState, nil)
 	diags = resp.State.Set(ctx, newState)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/folder_data_source.go
+++ b/internal/provider/folder_data_source.go
@@ -63,6 +63,11 @@ func (d *folderDataSource) Schema(
 				Computed:            true,
 				MarkdownDescription: "The ID of the folders's parent folder. 'root' is used for a folder at the root level.",
 			},
+			"labels": schema.MapAttribute{
+				Computed:            true,
+				ElementType:         types.StringType,
+				MarkdownDescription: "Map of key-value pairs used to organize and categorize resources.",
+			},
 		},
 	}
 }
@@ -157,6 +162,13 @@ func (d *folderDataSource) Read(
 	folderDataSource.ParentId = types.StringValue(folder.ParentId)
 	if folderDataSource.Path.IsNull() {
 		folderDataSource.Path = types.StringValue(buildFolderPathString(folder))
+	}
+
+	if folder.Labels == nil {
+		folderDataSource.Labels = types.MapNull(types.StringType)
+	} else {
+		folderDataSource.Labels, diags = types.MapValueFrom(ctx, types.StringType, folder.Labels)
+		resp.Diagnostics.Append(diags...)
 	}
 
 	diags = resp.State.Set(ctx, folderDataSource)

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -105,6 +105,7 @@ type CockroachCluster struct {
 	ParentId         types.String             `tfsdk:"parent_id"`
 	DeleteProtection types.Bool               `tfsdk:"delete_protection"`
 	BackupConfig     types.Object             `tfsdk:"backup_config"`
+	Labels           types.Map                `tfsdk:"labels"`
 }
 
 type AllowlistEntry struct {
@@ -317,6 +318,7 @@ type Folder struct {
 	ID       types.String `tfsdk:"id"`
 	Name     types.String `tfsdk:"name"`
 	ParentId types.String `tfsdk:"parent_id"`
+	Labels   types.Map    `tfsdk:"labels"`
 }
 
 type FolderDataSourceModel struct {
@@ -324,6 +326,7 @@ type FolderDataSourceModel struct {
 	Path     types.String `tfsdk:"path"`
 	Name     types.String `tfsdk:"name"`
 	ParentId types.String `tfsdk:"parent_id"`
+	Labels   types.Map    `tfsdk:"labels"`
 }
 
 type JWTIssuer struct {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// ToStringMap takes a types.Map object and converts it to map[string]string.
+func ToStringMap(m types.Map) (map[string]string, error) {
+	labels := make(map[string]string)
+	for k, v := range m.Elements() {
+		valueStr, ok := v.(types.String)
+		if !ok || valueStr.IsUnknown() || valueStr.IsNull() {
+			return nil, errors.New("value in map is null, unknown, or not a string")
+		}
+		labels[k] = valueStr.ValueString()
+	}
+	return labels, nil
+}

--- a/internal/validators/labels.go
+++ b/internal/validators/labels.go
@@ -1,0 +1,104 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/cockroachdb/terraform-provider-cockroach/internal/utils"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var labelKeyRegex = regexp.MustCompile("^[a-z][a-z0-9_-]*$")
+var labelValueRegex = regexp.MustCompile("^[a-z0-9_-]*$")
+
+const ResourceLabelLimit = 50
+
+func isLabelKeyValid(s string) bool {
+	// Requirements:
+	// Starts with lowercase letter.
+	// Contains only lowercase letters, numbers, "-", and "_".
+	// Length between 1 and 63 characters.
+	keyLength := len(s)
+	return keyLength >= 1 && keyLength <= 63 && labelKeyRegex.MatchString(s)
+}
+
+func isLabelValueValid(s string) bool {
+	// Requirements:
+	// Contains only lowercase letters, numbers, "-", and "_".
+	// Length between 0 and 63 characters.
+	valueLength := len(s)
+	return valueLength <= 63 && labelValueRegex.MatchString(s)
+}
+
+// getInvalidLabels returns a list of invalid labels found in the given label map.
+func getInvalidLabels(labels map[string]string) []string {
+	var invalidLabels []string
+	for k, v := range labels {
+		if !isLabelKeyValid(k) || !isLabelValueValid(v) {
+			invalidLabel := fmt.Sprintf("%s:%s", k, v)
+			invalidLabels = append(invalidLabels, invalidLabel)
+		}
+	}
+	return invalidLabels
+}
+
+// isValidLabels ensures all labels in the given label map are formatted correctly.
+func isValidLabels(labels map[string]string) bool {
+	invalidLabels := getInvalidLabels(labels)
+	return len(invalidLabels) <= 0
+}
+
+var _ validator.Map = labelsValidator{}
+
+type labelsValidator struct{}
+
+func (validator labelsValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("must contain at most %d key-value pairs, with each key and each value allowed up to 63 characters (lowercase letters, numbers, hyphens, or underscores)", ResourceLabelLimit)
+}
+
+func (validator labelsValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+func (validator labelsValidator) ValidateMap(
+	ctx context.Context, request validator.MapRequest, response *validator.MapResponse,
+) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() || len(request.ConfigValue.Elements()) == 0 {
+		return
+	}
+
+	value, diags := request.ConfigValue.ToMapValue(ctx)
+	response.Diagnostics.Append(diags...)
+
+	labels, err := utils.ToStringMap(value)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Error processing labels",
+			fmt.Sprintf("Could not convert labels: %v", err),
+		)
+	}
+
+	if len(labels) > ResourceLabelLimit {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			fmt.Sprintf("must contain at most %d key-value pairs", ResourceLabelLimit),
+			value.String(),
+		))
+	}
+
+	if !isValidLabels(labels) {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			"must have keys and values with a maximum of 63 characters, using only lowercase letters, numbers, hyphens (-), or underscores (_)",
+			value.String(),
+		))
+	}
+}
+
+// Labels returns an AttributeValidator which ensures that the
+// labels passed in are formatted correctly.
+func Labels() validator.Map {
+	return labelsValidator{}
+}


### PR DESCRIPTION
This commit adds support for managing labels through the cockroach_cluster and cockroach_folder resources in the Cockroach Terraform provider. Labels defined in Terraform are authoritative and will overwrite any labels added or removed outside of Terraform.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
