### PR TITLE
[FEB-93] add cluster attribute for full version string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+
+- Added `full_version` attribute to the cluster data source and resource for
+  fetching the full version string. (e.g. v25.1.0)
+
 ## [1.11.2] - 2025-02-07
 
 ### Fixed

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -33,10 +33,11 @@ data "cockroach_cluster" "cockroach" {
   * GCP
   * AWS
   * AZURE
-- `cockroach_version` (String) Full version of CockroachDB running on the cluster.
+- `cockroach_version` (String) The major version of CockroachDB running on the cluster. (e.g. v25.0)
 - `creator_id` (String) ID of the user who created the cluster.
 - `dedicated` (Attributes) (see [below for nested schema](#nestedatt--dedicated))
 - `delete_protection` (Boolean) Set to true to enable delete protection on the cluster.
+- `full_version` (String) The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)
 - `id` (String) The ID of this resource.
 - `name` (String) Name of the cluster.
 - `operation_status` (String) Describes the current long-running operation, if any.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -88,7 +88,7 @@ resource "cockroach_cluster" "basic" {
 
 - `backup_config` (Attributes) The backup settings for a cluster.
  Each cluster has backup settings that determine if backups are enabled, how frequently they are taken, and how long they are retained for. Use this attribute to manage those settings. (see [below for nested schema](#nestedatt--backup_config))
-- `cockroach_version` (String) Major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL').
+- `cockroach_version` (String) The major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL'). (e.g. v25.0)
 - `dedicated` (Attributes) (see [below for nested schema](#nestedatt--dedicated))
 - `delete_protection` (Boolean) Set to true to enable delete protection on the cluster. If unset, the server chooses the value on cluster creation, and preserves the value on cluster update.
 - `parent_id` (String) The ID of the cluster's parent folder. 'root' is used for a cluster at the root level.
@@ -99,6 +99,7 @@ resource "cockroach_cluster" "basic" {
 
 - `account_id` (String) The cloud provider account ID that hosts the cluster. Needed for CMEK and other advanced features.
 - `creator_id` (String) ID of the user who created the cluster.
+- `full_version` (String) The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)
 - `id` (String) The ID of this resource.
 - `operation_status` (String) Describes the current long-running operation, if any.
 - `state` (String) Describes whether the cluster is being created, updated, deleted, etc.

--- a/examples/workflows/cockroach_advanced_cluster/main.tf
+++ b/examples/workflows/cockroach_advanced_cluster/main.tf
@@ -168,3 +168,7 @@ output "cert" {
 output "connection_string" {
   value = data.cockroach_connection_string.example.connection_string
 }
+
+output "cluster_version" {
+  value = data.cockroach_cluster.example.full_version
+}

--- a/examples/workflows/cockroach_basic_cluster/main.tf
+++ b/examples/workflows/cockroach_basic_cluster/main.tf
@@ -85,3 +85,7 @@ output "example_cluster_op_key_v1_secret" {
   description = "The api key for example_cluster_op_key_v1_secret"
   sensitive   = true
 }
+
+output "cluster_version" {
+  value = data.cockroach_cluster.example.full_version
+}

--- a/examples/workflows/cockroach_standard_cluster/main.tf
+++ b/examples/workflows/cockroach_standard_cluster/main.tf
@@ -107,3 +107,7 @@ output "example_cluster_op_key_v1_secret" {
   description = "The api key for example_cluster_op_key_v1_secret"
   sensitive   = true
 }
+
+output "cluster_version" {
+  value = cockroach_cluster.example.full_version
+}

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -45,7 +45,11 @@ func (d *clusterDataSource) Schema(
 			},
 			"cockroach_version": schema.StringAttribute{
 				Computed:    true,
-				Description: "Full version of CockroachDB running on the cluster.",
+				Description: "The major version of CockroachDB running on the cluster. (e.g. v25.0)",
+			},
+			"full_version": schema.StringAttribute{
+				Computed: true,
+				MarkdownDescription: "The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)",
 			},
 			"plan": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -123,7 +123,11 @@ func (r *clusterResource) Schema(
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				MarkdownDescription: "Major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL').",
+				MarkdownDescription: "The major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL'). (e.g. v25.0)",
+			},
+			"full_version": schema.StringAttribute{
+				Computed: true,
+				MarkdownDescription: "The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)",
 			},
 			"account_id": schema.StringAttribute{
 				Computed: true,
@@ -1244,6 +1248,7 @@ func loadClusterToTerraformState(
 	state.CloudProvider = types.StringValue(string(clusterObj.CloudProvider))
 	planSpecifiesPreviewString := plan != nil && plan.CockroachVersion.ValueString() == clusterVersionPreview
 	state.CockroachVersion = types.StringValue(simplifyClusterVersion(clusterObj.CockroachVersion, planSpecifiesPreviewString))
+	state.FullVersion = types.StringValue(clusterObj.CockroachVersion)
 	state.Plan = types.StringValue(string(clusterObj.Plan))
 	if clusterObj.AccountId == nil {
 		state.AccountId = types.StringNull()

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -96,6 +96,7 @@ type CockroachCluster struct {
 	ServerlessConfig *ServerlessClusterConfig `tfsdk:"serverless"`
 	Regions          []Region                 `tfsdk:"regions"`
 	CockroachVersion types.String             `tfsdk:"cockroach_version"`
+	FullVersion      types.String             `tfsdk:"full_version"`
 	Plan             types.String             `tfsdk:"plan"`
 	State            types.String             `tfsdk:"state"`
 	CreatorId        types.String             `tfsdk:"creator_id"`


### PR DESCRIPTION
In order to orchestrate version upgrades we allow specifying the major version of the cluster in the cluster resource.  Originally the cluster data source exposed the full version string but having this value be a different format from the resource (major vs full) was causing confusion so the data source was changed to match the resource.

At this point, the full version string was not available in any resource or data source so we add it back here as "full_version".

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
