### PR TITLE
[CC-32431] fix inconsistent refresh behavior for labels

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -127,7 +127,7 @@ func (r *clusterResource) Schema(
 				MarkdownDescription: "The major version of CockroachDB running on the cluster. This value can be used to orchestrate version upgrades. Supported for ADVANCED and STANDARD clusters (when `serverless.upgrade_type` set to 'MANUAL'). (e.g. v25.0)",
 			},
 			"full_version": schema.StringAttribute{
-				Computed: true,
+				Computed:            true,
 				MarkdownDescription: "The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)",
 			},
 			"account_id": schema.StringAttribute{
@@ -1310,12 +1310,7 @@ func loadClusterToTerraformState(
 	}
 
 	var allDiags diag.Diagnostics
-
-	clusterLabels := make(map[string]string)
-	if clusterObj.Labels != nil {
-		clusterLabels = clusterObj.Labels
-	}
-	labels, diags := types.MapValueFrom(ctx, types.StringType, clusterLabels)
+	labels, diags := types.MapValueFrom(ctx, types.StringType, clusterObj.Labels)
 	state.Labels = labels
 	allDiags.Append(diags...)
 

--- a/internal/provider/folder_resource.go
+++ b/internal/provider/folder_resource.go
@@ -295,11 +295,7 @@ func loadFolderToTerraformState(
 	state.ParentId = types.StringValue(folderObj.ParentId)
 	state.Name = types.StringValue(folderObj.Name)
 
-	folderLabels := make(map[string]string)
-	if folderObj.Labels != nil {
-		folderLabels = folderObj.Labels
-	}
-	labels, diags := types.MapValueFrom(ctx, types.StringType, folderLabels)
+	labels, diags := types.MapValueFrom(ctx, types.StringType, folderObj.Labels)
 	state.Labels = labels
 	return diags
 }


### PR DESCRIPTION
When the resource has some labels set on it, a terraform refresh will update the state. When a resource has no labels set on it in terraform, a terraform refresh does not update the state. This commit fixes this inconsistent behavior.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
