### PR TITLE
add AWS external_id support for metric/log export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.12.0] - 2025-04-30
+## [1.12.0] - 2025-04-25
 
 ### Added
 
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `full_version` attribute to the cluster data source and resource for
   fetching the full version string. (e.g. v25.1.0)
+
+- Added AWS external ID support for both CloudWatch metric export and log export configurations.
+
+### Fixed
+
+- Fixed an issue where fields, in metric/log export, incorrectly marked as
+computed led to miscalculation of diffs when fields were commented out or
+removed from the terraform config
 
 ## [1.11.2] - 2025-02-07
 

--- a/docs/resources/log_export_config.md
+++ b/docs/resources/log_export_config.md
@@ -21,12 +21,17 @@ variable "auth_principal" {
   type = string
 }
 
+variable "aws_external_id" {
+  type = string
+}
+
 resource "cockroach_log_export_config" "example" {
-  id             = var.cluster_id
-  auth_principal = var.auth_principal
-  log_name       = "example"
-  type           = "GCP_CLOUD_LOGGING"
-  redact         = true
+  id              = var.cluster_id
+  auth_principal  = var.auth_principal
+  log_name        = "example"
+  type            = "GCP_CLOUD_LOGGING"
+  redact          = true
+  aws_external_id = var.aws_external_id
   groups = [
     {
       log_name : "sql",
@@ -58,6 +63,7 @@ resource "cockroach_log_export_config" "example" {
 
 ### Optional
 
+- `aws_external_id` (String) The external ID to use when assuming the AWS role.
 - `groups` (Attributes List) (see [below for nested schema](#nestedatt--groups))
 - `omitted_channels` (List of String) Controls what CRDB channels do not get exported.
 - `redact` (Boolean) Controls whether logs are redacted before forwarding to customer sinks.

--- a/docs/resources/metric_export_cloudwatch_config.md
+++ b/docs/resources/metric_export_cloudwatch_config.md
@@ -31,7 +31,12 @@ variable "aws_region" {
   type = string
 }
 
+variable "external_id" {
+  type = string
+}
+
 resource "cockroach_metric_export_cloudwatch_config" "example" {
+  external_id    = var.external_id
   id             = var.cluster_id
   role_arn       = var.role_arn
   log_group_name = var.log_group_name
@@ -49,6 +54,7 @@ resource "cockroach_metric_export_cloudwatch_config" "example" {
 
 ### Optional
 
+- `external_id` (String) The external ID to use when assuming the IAM role for CloudWatch metric export.
 - `log_group_name` (String) The customized AWS CloudWatch log group name.
 - `target_region` (String) The specific AWS region that the metrics will be exported to.
 

--- a/examples/resources/cockroach_log_export_config/resource.tf
+++ b/examples/resources/cockroach_log_export_config/resource.tf
@@ -6,12 +6,17 @@ variable "auth_principal" {
   type = string
 }
 
+variable "aws_external_id" {
+  type = string
+}
+
 resource "cockroach_log_export_config" "example" {
-  id             = var.cluster_id
-  auth_principal = var.auth_principal
-  log_name       = "example"
-  type           = "GCP_CLOUD_LOGGING"
-  redact         = true
+  id              = var.cluster_id
+  auth_principal  = var.auth_principal
+  log_name        = "example"
+  type            = "GCP_CLOUD_LOGGING"
+  redact          = true
+  aws_external_id = var.aws_external_id
   groups = [
     {
       log_name : "sql",

--- a/examples/resources/cockroach_metric_export_cloudwatch_config/resource.tf
+++ b/examples/resources/cockroach_metric_export_cloudwatch_config/resource.tf
@@ -16,7 +16,12 @@ variable "aws_region" {
   type = string
 }
 
+variable "external_id" {
+  type = string
+}
+
 resource "cockroach_metric_export_cloudwatch_config" "example" {
+  external_id    = var.external_id
   id             = var.cluster_id
   role_arn       = var.role_arn
   log_group_name = var.log_group_name

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.0
 toolchain go1.22.8
 
 require (
-	github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.0.0
+	github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.1.0
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-retryablehttp v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vc
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.0.0 h1:jhaiDARRzFam+lN3Gkzv4JKsvGZFjW3lKfEVLLllq5w=
 github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.0.0/go.mod h1:8l4PNIhne5ZKgIBFYHF+1IiKwtL2oCH1FhVACby8YmU=
+github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.1.0 h1:hYdQ5lgKHT9qSn3czav9awVAFsHzYrIx9MFBnLJdiSg=
+github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.1.0/go.mod h1:8l4PNIhne5ZKgIBFYHF+1IiKwtL2oCH1FhVACby8YmU=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/provider/metric_export_cloudwatch_config_resource_test.go
+++ b/internal/provider/metric_export_cloudwatch_config_resource_test.go
@@ -83,23 +83,25 @@ func TestIntegrationMetricExportCloudWatchConfigResource(t *testing.T) {
 	enabledStatus := client.METRICEXPORTSTATUSTYPE_ENABLED
 	arn := "test-role-arn"
 	logGroupName := "example"
-	emptyString := ""
 	updatedRegion := "us-east-1"
 
 	createdCloudWatchClusterInfo := &client.CloudWatchMetricExportInfo{
 		ClusterId:    clusterID,
 		RoleArn:      arn,
 		LogGroupName: &logGroupName,
-		TargetRegion: &emptyString,
+		TargetRegion: nil,
 		Status:       &enabledStatus,
+		ExternalId:   nil,
 	}
 
+	updatedExternalID := "test-external-id"
 	updatedCloudWatchClusterInfo := &client.CloudWatchMetricExportInfo{
 		ClusterId:    clusterID,
 		RoleArn:      arn,
 		LogGroupName: &logGroupName,
 		TargetRegion: &updatedRegion,
 		Status:       &enabledStatus,
+		ExternalId:   &updatedExternalID,
 	}
 
 	// Create
@@ -114,6 +116,7 @@ func TestIntegrationMetricExportCloudWatchConfigResource(t *testing.T) {
 		&client.EnableCloudWatchMetricExportRequest{
 			RoleArn:      arn,
 			LogGroupName: &logGroupName,
+			ExternalId:   nil,
 		}).
 		Return(createdCloudWatchClusterInfo, nil, nil)
 	s.EXPECT().GetCloudWatchMetricExportInfo(gomock.Any(), clusterID).
@@ -131,6 +134,7 @@ func TestIntegrationMetricExportCloudWatchConfigResource(t *testing.T) {
 			RoleArn:      arn,
 			LogGroupName: &logGroupName,
 			TargetRegion: &updatedRegion,
+			ExternalId:   &updatedExternalID,
 		}).
 		Return(updatedCloudWatchClusterInfo, nil, nil)
 	s.EXPECT().GetCloudWatchMetricExportInfo(gomock.Any(), clusterID).
@@ -161,7 +165,8 @@ func testMetricExportCloudWatchConfigResource(t *testing.T, clusterName string, 
 					testMetricExportCloudWatchConfigExists(metricExportCloudWatchConfigResourceName, clusterResourceName),
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "role_arn", "test-role-arn"),
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "log_group_name", "example"),
-					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "target_region", ""),
+					resource.TestCheckNoResourceAttr(metricExportCloudWatchConfigResourceName, "target_region"),
+					resource.TestCheckNoResourceAttr(metricExportCloudWatchConfigResourceName, "external_id"),
 				),
 			},
 			{
@@ -171,6 +176,7 @@ func testMetricExportCloudWatchConfigResource(t *testing.T, clusterName string, 
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "role_arn", "test-role-arn"),
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "log_group_name", "example"),
 					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "target_region", "us-east-1"),
+					resource.TestCheckResourceAttr(metricExportCloudWatchConfigResourceName, "external_id", "test-external-id"),
 				),
 			},
 			{
@@ -219,20 +225,20 @@ resource "cockroach_cluster" "test" {
   name           = "%s"
   cloud_provider = "AWS"
   dedicated = {
-    storage_gib = 35
-  	num_virtual_cpus = 4
+    storage_gib      = 35
+    num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
-    node_count: 3
+    node_count : 3
   }]
 }
 
 resource "cockroach_metric_export_cloudwatch_config" "test" {
-	id      = cockroach_cluster.test.id
-	role_arn       = "test-role-arn"
-	log_group_name = "example"
-  }
+  id             = cockroach_cluster.test.id
+  role_arn       = "test-role-arn"
+  log_group_name = "example"
+}
 `, name)
 }
 
@@ -242,20 +248,21 @@ resource "cockroach_cluster" "test" {
   name           = "%s"
   cloud_provider = "AWS"
   dedicated = {
-    storage_gib = 35
-  	num_virtual_cpus = 4
+    storage_gib      = 35
+    num_virtual_cpus = 4
   }
   regions = [{
     name = "us-east-1"
-    node_count: 3
+    node_count : 3
   }]
 }
 
 resource "cockroach_metric_export_cloudwatch_config" "test" {
-	id      = cockroach_cluster.test.id
-	role_arn       = "test-role-arn"
-	log_group_name = "example"
-	target_region  = "us-east-1"
-  }
+  id             = cockroach_cluster.test.id
+  role_arn       = "test-role-arn"
+  log_group_name = "example"
+  target_region  = "us-east-1"
+  external_id    = "test-external-id"
+}
 `, name)
 }

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -248,6 +248,7 @@ type ClusterLogExport struct {
 	CreatedAt       types.String      `tfsdk:"created_at"`
 	UpdatedAt       types.String      `tfsdk:"updated_at"`
 	OmittedChannels *[]types.String   `tfsdk:"omitted_channels"`
+	AWSExternalID   types.String      `tfsdk:"aws_external_id"`
 }
 
 type ClusterCloudWatchMetricExportConfig struct {
@@ -255,6 +256,7 @@ type ClusterCloudWatchMetricExportConfig struct {
 	TargetRegion types.String `tfsdk:"target_region"`
 	LogGroupName types.String `tfsdk:"log_group_name"`
 	RoleArn      types.String `tfsdk:"role_arn"`
+	ExternalID   types.String `tfsdk:"external_id"`
 	UserMessage  types.String `tfsdk:"user_message"`
 	Status       types.String `tfsdk:"status"`
 }

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_audit_log_action.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_audit_log_action.go
@@ -106,6 +106,7 @@ const (
 	AUDITLOGACTION_UPDATE_JWT_ISSUER                       AuditLogAction = "AUDIT_LOG_ACTION_UPDATE_JWT_ISSUER"
 	AUDITLOGACTION_CREATE_LICENSE                          AuditLogAction = "AUDIT_LOG_ACTION_CREATE_LICENSE"
 	AUDITLOGACTION_UPDATE_ORGANIZATION_NAME                AuditLogAction = "AUDIT_LOG_ACTION_UPDATE_ORGANIZATION_NAME"
+	AUDITLOGACTION_CREATE_LICENSES                         AuditLogAction = "AUDIT_LOG_ACTION_CREATE_LICENSES"
 )
 
 // All allowed values of AuditLogAction enum.
@@ -189,6 +190,7 @@ var AllowedAuditLogActionEnumValues = []AuditLogAction{
 	"AUDIT_LOG_ACTION_UPDATE_JWT_ISSUER",
 	"AUDIT_LOG_ACTION_CREATE_LICENSE",
 	"AUDIT_LOG_ACTION_UPDATE_ORGANIZATION_NAME",
+	"AUDIT_LOG_ACTION_CREATE_LICENSES",
 }
 
 // NewAuditLogActionFromValue returns a pointer to a valid AuditLogAction

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_cloud_watch_metric_export_info.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_cloud_watch_metric_export_info.go
@@ -21,6 +21,8 @@ package client
 // CloudWatchMetricExportInfo struct for CloudWatchMetricExportInfo.
 type CloudWatchMetricExportInfo struct {
 	ClusterId string `json:"cluster_id"`
+	// external_id, if set, is included when assuming the IAM role. Supported for Advanced clusters only.
+	ExternalId *string `json:"external_id,omitempty"`
 	// log_group_name is the customized log group name.
 	LogGroupName *string `json:"log_group_name,omitempty"`
 	// role_arn is the IAM role used to upload metric segments to the target AWS account.
@@ -63,6 +65,20 @@ func (o *CloudWatchMetricExportInfo) GetClusterId() string {
 // SetClusterId sets field value.
 func (o *CloudWatchMetricExportInfo) SetClusterId(v string) {
 	o.ClusterId = v
+}
+
+// GetExternalId returns the ExternalId field value if set, zero value otherwise.
+func (o *CloudWatchMetricExportInfo) GetExternalId() string {
+	if o == nil || o.ExternalId == nil {
+		var ret string
+		return ret
+	}
+	return *o.ExternalId
+}
+
+// SetExternalId gets a reference to the given string and assigns it to the ExternalId field.
+func (o *CloudWatchMetricExportInfo) SetExternalId(v string) {
+	o.ExternalId = &v
 }
 
 // GetLogGroupName returns the LogGroupName field value if set, zero value otherwise.

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_enable_cloud_watch_metric_export_request.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_enable_cloud_watch_metric_export_request.go
@@ -20,6 +20,8 @@ package client
 
 // EnableCloudWatchMetricExportRequest struct for EnableCloudWatchMetricExportRequest.
 type EnableCloudWatchMetricExportRequest struct {
+	// external_id to include when assuming the IAM role specified by role_arn. Optional. A specific value may be required by the role's trust policy. Only supported for Advanced clusters. If provided for a Standard cluster, the request is rejected.
+	ExternalId *string `json:"external_id,omitempty"`
 	// log_group_name is the customized log group name.
 	LogGroupName *string `json:"log_group_name,omitempty"`
 	// role_arn is the IAM role used to upload metric segments to the target AWS account.
@@ -44,6 +46,20 @@ func NewEnableCloudWatchMetricExportRequest(roleArn string) *EnableCloudWatchMet
 func NewEnableCloudWatchMetricExportRequestWithDefaults() *EnableCloudWatchMetricExportRequest {
 	p := EnableCloudWatchMetricExportRequest{}
 	return &p
+}
+
+// GetExternalId returns the ExternalId field value if set, zero value otherwise.
+func (o *EnableCloudWatchMetricExportRequest) GetExternalId() string {
+	if o == nil || o.ExternalId == nil {
+		var ret string
+		return ret
+	}
+	return *o.ExternalId
+}
+
+// SetExternalId gets a reference to the given string and assigns it to the ExternalId field.
+func (o *EnableCloudWatchMetricExportRequest) SetExternalId(v string) {
+	o.ExternalId = &v
 }
 
 // GetLogGroupName returns the LogGroupName field value if set, zero value otherwise.

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_enable_log_export_request.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_enable_log_export_request.go
@@ -21,6 +21,8 @@ package client
 // EnableLogExportRequest struct for EnableLogExportRequest.
 type EnableLogExportRequest struct {
 	AuthPrincipal string `json:"auth_principal"`
+	// aws_external_id to include when assuming the IAM role specified by role_arn. Optional. A specific value may be required by the role's trust policy. Only supported for Advanced clusters on AWS. If provided for a Standard cluster, the request is rejected.
+	AwsExternalId *string `json:"aws_external_id,omitempty"`
 	// The primary or the secondary connected sources client authentication key. This is used to export logs to Azure Log Analytics.
 	AzureSharedKey *string `json:"azure_shared_key,omitempty"`
 	// groups is a collection of log group configurations that allows the customer to define collections of CRDB log channels that are aggregated separately at the target sink.
@@ -69,6 +71,20 @@ func (o *EnableLogExportRequest) GetAuthPrincipal() string {
 // SetAuthPrincipal sets field value.
 func (o *EnableLogExportRequest) SetAuthPrincipal(v string) {
 	o.AuthPrincipal = v
+}
+
+// GetAwsExternalId returns the AwsExternalId field value if set, zero value otherwise.
+func (o *EnableLogExportRequest) GetAwsExternalId() string {
+	if o == nil || o.AwsExternalId == nil {
+		var ret string
+		return ret
+	}
+	return *o.AwsExternalId
+}
+
+// SetAwsExternalId gets a reference to the given string and assigns it to the AwsExternalId field.
+func (o *EnableLogExportRequest) SetAwsExternalId(v string) {
+	o.AwsExternalId = &v
 }
 
 // GetAzureSharedKey returns the AzureSharedKey field value if set, zero value otherwise.

--- a/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_log_export_cluster_specification.go
+++ b/vendor/github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client/model_log_export_cluster_specification.go
@@ -22,6 +22,8 @@ package client
 type LogExportClusterSpecification struct {
 	// auth_principal is either the AWS Role ARN that identifies a role that the cluster account can assume to write to CloudWatch or the GCP Project ID that the cluster service account has permissions to write to for cloud logging.
 	AuthPrincipal *string `json:"auth_principal,omitempty"`
+	// aws_external_id, if set, is included when assuming the IAM role. Supported for Advanced clusters on AWS only.
+	AwsExternalId *string `json:"aws_external_id,omitempty"`
 	// The primary or the secondary connected sources client authentication key. This is used to export logs to Azure Log Analytics.
 	AzureSharedKey *string `json:"azure_shared_key,omitempty"`
 	// groups is a collection of log group configurations to customize which CRDB channels get aggregated into different groups at the target sink. Unconfigured channels will be sent to the default locations via the settings above.
@@ -58,6 +60,20 @@ func (o *LogExportClusterSpecification) GetAuthPrincipal() string {
 // SetAuthPrincipal gets a reference to the given string and assigns it to the AuthPrincipal field.
 func (o *LogExportClusterSpecification) SetAuthPrincipal(v string) {
 	o.AuthPrincipal = &v
+}
+
+// GetAwsExternalId returns the AwsExternalId field value if set, zero value otherwise.
+func (o *LogExportClusterSpecification) GetAwsExternalId() string {
+	if o == nil || o.AwsExternalId == nil {
+		var ret string
+		return ret
+	}
+	return *o.AwsExternalId
+}
+
+// SetAwsExternalId gets a reference to the given string and assigns it to the AwsExternalId field.
+func (o *LogExportClusterSpecification) SetAwsExternalId(v string) {
+	o.AwsExternalId = &v
 }
 
 // GetAzureSharedKey returns the AzureSharedKey field value if set, zero value otherwise.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -60,7 +60,7 @@ github.com/cloudflare/circl/math/mlsbset
 github.com/cloudflare/circl/sign
 github.com/cloudflare/circl/sign/ed25519
 github.com/cloudflare/circl/sign/ed448
-# github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.0.0
+# github.com/cockroachdb/cockroach-cloud-sdk-go/v6 v6.1.0
 ## explicit; go 1.17
 github.com/cockroachdb/cockroach-cloud-sdk-go/v6/pkg/client
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
This commit implements external_id support for both CloudWatch metric export
and log export configurations. External ID is used when assuming AWS IAM
roles and provides additional security for cross-account access.

Changes:

  * Upgrade cockroach-cloud-sdk-go to  v6.1.0
  * Add external_id field to CloudWatch metric export resource
  * Add aws_external_id field to log export resource
  * Update tests for both resources
  * Addresses an issue where fields incorrectly marked as computed led to
    miscalculation of diffs when fields were commented out or removed from the
    terraform config
  * Ensures backward compatibility for existing configurations

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] ~Acceptance test(s)~ Acc tests have been skipped for these resources. I've manually tested this extensively on a staging cluster. Will create a separate follow up ticket to enable the Acc tests if required. 
- [x] Example(s)
