### PR TITLE
[CLOUDOPS-13734] handle external deletion of service account in user role grant resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.1] - 2025-05-01
+
+### Fixed
+
+- Fixed an inconsistency error caused by user role grant resources referencing service
+  accounts (managed by Terraform) that are deleted externally.
+
 ## [1.12.0] - 2025-04-25
 
 ### Added

--- a/internal/provider/user_role_grant_resource.go
+++ b/internal/provider/user_role_grant_resource.go
@@ -26,6 +26,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -42,6 +44,14 @@ func (r *userRoleGrantResource) Schema(
 			"user_id": schema.StringAttribute{
 				Required:    true,
 				Description: "ID of the user to grant these roles to.",
+				// RequiresReplace ensures that the user role grant resource is replaced
+				// when the user_id changes. This can happen when the service account
+				// associated with the user_id is managed by Terraform and gets deleted
+				// externally, prompting Terraform to create a new service account on
+				// apply.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"role": schema.SingleNestedAttribute{
 				Required: true,


### PR DESCRIPTION
Previously, the external deletion of a service account resource managed in Terraform caused errors on apply if there was a user role grant resource that referenced the user ID associated with the deleted service account. This PR fixes this issue by adding a RequireReplace plan modifier on the UserID attribute of the UserRoleGrant resource.


**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`) - not relevant
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s) - not relevant
