### PR TITLE
Expose private_endpoint_dns in region list

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -82,6 +82,7 @@ Read-Only:
 - `name` (String) Region code used by the cluster's cloud provider.
 - `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
 - `primary` (Boolean) Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.
+- `private_endpoint_dns` (String) Private Endpoint DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -133,6 +133,7 @@ Optional:
 Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
+- `private_endpoint_dns` (String) Private Endpoint DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -87,6 +87,7 @@ Optional:
 Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
+- `private_endpoint_dns` (String) Private Endpoint DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -49,7 +49,7 @@ func (d *clusterDataSource) Schema(
 				Description: "The major version of CockroachDB running on the cluster. (e.g. v25.0)",
 			},
 			"full_version": schema.StringAttribute{
-				Computed: true,
+				Computed:            true,
 				MarkdownDescription: "The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)",
 			},
 			"plan": schema.StringAttribute{
@@ -153,6 +153,11 @@ func (d *clusterDataSource) Schema(
 							Computed:    true,
 							Description: "Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.",
 						},
+						"private_endpoint_dns": schema.StringAttribute{
+							Computed:    true,
+							Description: "Private Endpoint DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.",
+						},
+
 						"node_count": schema.Int64Attribute{
 							Computed:    true,
 							Description: "Number of nodes in the region. Will always be 0 for serverless clusters.",

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -86,6 +86,10 @@ var regionSchema = schema.NestedAttributeObject{
 			Computed:    true,
 			Description: "Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.",
 		},
+		"private_endpoint_dns": schema.StringAttribute{
+			Computed:    true,
+			Description: "Private Endpoint DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.",
+		},
 		"node_count": schema.Int64Attribute{
 			Optional: true,
 			Computed: true,
@@ -1438,12 +1442,13 @@ func getManagedRegions(apiRegions *[]client.Region, plan []Region) []Region {
 	for _, x := range *apiRegions {
 		if isDatasourceOrImport || planRegions[x.Name] {
 			rg := Region{
-				Name:        types.StringValue(x.Name),
-				SqlDns:      types.StringValue(x.SqlDns),
-				UiDns:       types.StringValue(x.UiDns),
-				InternalDns: types.StringValue(x.InternalDns),
-				NodeCount:   types.Int64Value(int64(x.NodeCount)),
-				Primary:     types.BoolValue(x.GetPrimary()),
+				Name:               types.StringValue(x.Name),
+				SqlDns:             types.StringValue(x.SqlDns),
+				UiDns:              types.StringValue(x.UiDns),
+				InternalDns:        types.StringValue(x.InternalDns),
+				PrivateEndpointDns: types.StringValue(x.PrivateEndpointDns),
+				NodeCount:          types.Int64Value(int64(x.NodeCount)),
+				Primary:            types.BoolValue(x.GetPrimary()),
 			}
 			regions = append(regions, rg)
 		}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -32,12 +32,13 @@ const (
 )
 
 type Region struct {
-	Name        types.String `tfsdk:"name"`
-	SqlDns      types.String `tfsdk:"sql_dns"`
-	UiDns       types.String `tfsdk:"ui_dns"`
-	InternalDns types.String `tfsdk:"internal_dns"`
-	NodeCount   types.Int64  `tfsdk:"node_count"`
-	Primary     types.Bool   `tfsdk:"primary"`
+	Name               types.String `tfsdk:"name"`
+	SqlDns             types.String `tfsdk:"sql_dns"`
+	UiDns              types.String `tfsdk:"ui_dns"`
+	InternalDns        types.String `tfsdk:"internal_dns"`
+	PrivateEndpointDns types.String `tfsdk:"private_endpoint_dns"`
+	NodeCount          types.Int64  `tfsdk:"node_count"`
+	Primary            types.Bool   `tfsdk:"primary"`
 }
 
 type DedicatedClusterConfig struct {


### PR DESCRIPTION
Expose private_endpoint_dns in the region list. It is necessary for creating a Google PSC connection.

Closes https://github.com/cockroachdb/terraform-provider-cockroach/issues/280

**Commit checklist**
- [ ] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
