### PR TITLE
Add UseStateForUnknown plan modifier to sql_dns and internal_dns

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -77,6 +77,9 @@ var regionSchema = schema.NestedAttributeObject{
 		"sql_dns": schema.StringAttribute{
 			Computed:    true,
 			Description: "DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"ui_dns": schema.StringAttribute{
 			Computed:    true,
@@ -85,6 +88,9 @@ var regionSchema = schema.NestedAttributeObject{
 		"internal_dns": schema.StringAttribute{
 			Computed:    true,
 			Description: "Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"node_count": schema.Int64Attribute{
 			Optional: true,


### PR DESCRIPTION
The sql_dns and internal_dns fields are assigned at cluster creation and remain static afterward. However, the Terraform provider did not previously reflect this behavior, causing these fields to be marked as "known after apply" in every plan and apply.

This commit adds the UseStateForUnknown plan modifier to both fields so that after the initial apply (cluster creation), the provider will use the values stored in the state.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
