### PR TITLE
Update CHANGELOG with dns field update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.12.2] - 2025-06-17
+
+### Fixed
+
+- Mark `internal_dns` and `sql_dns` fields in cluster resources as stable after creation.
+
 ## [1.12.1] - 2025-05-01
 
 ### Fixed


### PR DESCRIPTION
This commit updates the CHANGELOG to reflect the fix added to prevent the internal_dns and sql_dns fields from being marked as `known after apply` after the creation of the cluster resource.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
