### PR TITLE
[CLOUDOPS-15937] Retry enable log export config on lock error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed an issue where enabling log export configs did not account for lock errors.
+
 ## [1.13.1]
 
 ### Fixed


### PR DESCRIPTION
Previously, the retry logic for enabling log export configs did not account for lock errors. This resulted in failure to enable log export configs when the cluster was locked.

This patch adds logic to retry enabling log export configs when the cluster is locked.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
