### PR TITLE
[CNSL-1406] Expose private_endpoint_dns in cluster region list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `private_endpoint_dns` as a read-only attribute in the `cockroach_cluster` resource.
+
 ### Fixed
 - Prevent errors when `status` field in cockroach_cluster resource drifts due to
   external changes.

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -83,6 +83,7 @@ Read-Only:
 - `name` (String) Region code used by the cluster's cloud provider.
 - `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
 - `primary` (Boolean) Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.
+- `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -133,6 +133,7 @@ Optional:
 Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
+- `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -88,6 +88,7 @@ Optional:
 Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
+- `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -157,6 +157,10 @@ func (d *clusterDataSource) Schema(
 							Computed:    true,
 							Description: "Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.",
 						},
+						"private_endpoint_dns": schema.StringAttribute{
+							Computed:    true,
+							Description: "Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.",
+						},
 						"node_count": schema.Int64Attribute{
 							Computed:    true,
 							Description: "Number of nodes in the region. Will always be 0 for serverless clusters.",

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -91,6 +91,9 @@ var regionSchema = schema.NestedAttributeObject{
 			PlanModifiers: []planmodifier.String{
 				stringplanmodifier.UseStateForUnknown(),
 			},
+		}, "private_endpoint_dns": schema.StringAttribute{
+			Computed:    true,
+			Description: "Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.",
 		},
 		"node_count": schema.Int64Attribute{
 			Optional: true,
@@ -1467,12 +1470,13 @@ func getManagedRegions(apiRegions *[]client.Region, plan []Region) []Region {
 	for _, x := range *apiRegions {
 		if isDatasourceOrImport || planRegions[x.Name] {
 			rg := Region{
-				Name:        types.StringValue(x.Name),
-				SqlDns:      types.StringValue(x.SqlDns),
-				UiDns:       types.StringValue(x.UiDns),
-				InternalDns: types.StringValue(x.InternalDns),
-				NodeCount:   types.Int64Value(int64(x.NodeCount)),
-				Primary:     types.BoolValue(x.GetPrimary()),
+				Name:               types.StringValue(x.Name),
+				SqlDns:             types.StringValue(x.SqlDns),
+				UiDns:              types.StringValue(x.UiDns),
+				InternalDns:        types.StringValue(x.InternalDns),
+				PrivateEndpointDns: types.StringValue(x.PrivateEndpointDns),
+				NodeCount:          types.Int64Value(int64(x.NodeCount)),
+				Primary:            types.BoolValue(x.GetPrimary()),
 			}
 			regions = append(regions, rg)
 		}

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -32,12 +32,13 @@ const (
 )
 
 type Region struct {
-	Name        types.String `tfsdk:"name"`
-	SqlDns      types.String `tfsdk:"sql_dns"`
-	UiDns       types.String `tfsdk:"ui_dns"`
-	InternalDns types.String `tfsdk:"internal_dns"`
-	NodeCount   types.Int64  `tfsdk:"node_count"`
-	Primary     types.Bool   `tfsdk:"primary"`
+	Name               types.String `tfsdk:"name"`
+	SqlDns             types.String `tfsdk:"sql_dns"`
+	UiDns              types.String `tfsdk:"ui_dns"`
+	InternalDns        types.String `tfsdk:"internal_dns"`
+	PrivateEndpointDns types.String `tfsdk:"private_endpoint_dns"`
+	NodeCount          types.Int64  `tfsdk:"node_count"`
+	Primary            types.Bool   `tfsdk:"primary"`
 }
 
 type DedicatedClusterConfig struct {


### PR DESCRIPTION
Previously, `private_endpoint_dns` was not exposed in the cluster region list. Since it is used to connect a cluster to GCP Private Service Connect, customers needed to manually retrieve the `private_endpoint_dns` from the CockroachCloud UI or API, breaking end-to-end automation.

This change adds `private_endpoint_dns` to the cluster region list to allow customers to directly access it via Terraform.

This commit builds on #281.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
