### PR TITLE
Update CHANGELOG for 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.0] - 2025-09-02
+
 ### Added
 
 - Added cockroach_restore resource for starting restore jobs from a managed backup.


### PR DESCRIPTION
Move the Unreleased section into a new 1.14.0 entry dated 2025-09-02. No other files were modified.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
