### PR TITLE
Update 1.14.0 release date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.14.0] - 2025-09-02
+## [1.14.0] - 2025-09-03
 
 ### Added
 


### PR DESCRIPTION
This commit updates the release date for version 1.14.0 to 2025-09-03 in the CHANGELOG.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
