### PR TITLE
remove plan modifier from `state` field in cluster resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Prevent errors when `status` field in cockroach_cluster resource drifts due to
+  external changes.
+
 ## [1.14.0] - 2025-09-03
 
 ### Added

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -288,10 +288,7 @@ func (r *clusterResource) Schema(
 				NestedObject: regionSchema,
 			},
 			"state": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:    true,
 				Description: "Describes whether the cluster is being created, updated, deleted, etc.",
 			},
 			"creator_id": schema.StringAttribute{


### PR DESCRIPTION
This commit removes the `UseStateForUnknown` plan modifier from the `state` field to prevent errors when the computed field drifts due to external changes.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
