### PR TITLE
Update CHANGELOG for v1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.0] - 2025-09-30
+
 ### Added
 
 - Added acceptance test for cockroach_backups data source.


### PR DESCRIPTION
Update the CHANGELOG for the v1.15.0 release with release date 2025-09-30.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
