### PR TITLE
Stopped using state for unknown `Cluster.account_id` values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Stopped using state for unknown `account_id` in the `Cluster` resource because
+  it can change when swapping between basic and standard plans.
+
 - Updated egress private endpoint resource to reflect changes to the
   underlying GET API.
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -141,10 +141,7 @@ func (r *clusterResource) Schema(
 				MarkdownDescription: "The full version string of CockroachDB running on the cluster. (e.g. v25.0.1)",
 			},
 			"account_id": schema.StringAttribute{
-				Computed: true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				Computed:    true,
 				Description: "The cloud provider account ID that hosts the cluster. Needed for CMEK and other advanced features.",
 			},
 			"customer_cloud_account": schema.SingleNestedAttribute{


### PR DESCRIPTION
This value can actually change when swapping a cluster between basic and standard plans, which causes an error with this plan modifier. This fixes some failing acceptance tests that act on serverless clusters.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
