### PR TITLE
Update CHANGELOG for v1.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-03-20
+
 ### Added
 
 - Added new `cockroach_egress_traffic_policy` resource for managing the egress


### PR DESCRIPTION
This commit updates the CHANGELOG for the v1.18.0 release with release date 2026-03-20.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s)
