### PR TITLE
[CNSL-1743] clarify disk_iops documentation

### DIFF
--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -101,7 +101,7 @@ Read-Only:
 Read-Only:
 
 - `cidr_range` (String) The IPv4 range in CIDR format that is in use by the cluster. It is only set on GCP clusters and is otherwise empty.
-- `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default.
+- `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. This value reflects the actual provisioned IOPS, which may differ from the value specified during cluster creation or update. A value of zero indicates the cloud provider-specific default.
 - `machine_type` (String) Machine type identifier within the given cloud provider, ex. m6.xlarge, n2-standard-4.
 - `memory_gib` (Number) Memory per node in GiB.
 - `num_virtual_cpus` (Number) Number of virtual CPUs per node in the cluster.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -190,7 +190,7 @@ Required:
 Optional:
 
 - `cidr_range` (String) The IPv4 range in CIDR format that will be used by the cluster. This is supported only on GCP, and must have a subnet mask no larger than /19. Defaults to "172.28.0.0/14". This cannot be changed after cluster creation.
-- `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. Omitting this attribute will result in the cloud provider-specific default.
+- `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. Only configurable for AWS clusters during creation. For GCP and Azure clusters, this value is ignored and the cloud provider default is used. Omit this attribute to use the server-side default based on machine type and storage size. The provisioned value may differ from the requested value.
 - `machine_type` (String) Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4. This attribute requires a feature flag to be enabled. It is recommended to leave this empty and use `num_virtual_cpus` to control the machine type.
 - `num_virtual_cpus` (Number) Number of virtual CPUs per node in the cluster.
 - `private_network_visibility` (Boolean) Set to true to assign private IP addresses to nodes. Required for CMEK and other advanced networking features. Clusters created with this flag will have advanced security features enabled.  This cannot be changed after cluster creation and incurs additional charges.  See [Create an Advanced Cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-an-advanced-cluster.html#step-6-configure-advanced-security-features) and [Pricing](https://www.cockroachlabs.com/pricing/) for more information.

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -161,7 +161,7 @@ func (d *clusterDataSource) Schema(
 					},
 					"disk_iops": schema.Int64Attribute{
 						Computed:    true,
-						Description: "Number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default.",
+						Description: "Number of disk I/O operations per second that are permitted on each node in the cluster. This value reflects the actual provisioned IOPS, which may differ from the value specified during cluster creation or update. A value of zero indicates the cloud provider-specific default.",
 					},
 					"private_network_visibility": schema.BoolAttribute{
 						Computed:    true,

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -284,7 +284,7 @@ func (r *clusterResource) Schema(
 							// returned but it causes a provider inconsistency.
 							int64validator.AtLeast(1),
 						},
-						Description: "Number of disk I/O operations per second that are permitted on each node in the cluster. Omitting this attribute will result in the cloud provider-specific default.",
+						Description: "Number of disk I/O operations per second that are permitted on each node in the cluster. Only configurable for AWS clusters during creation. For GCP and Azure clusters, this value is ignored and the cloud provider default is used. Omit this attribute to use the server-side default based on machine type and storage size. The provisioned value may differ from the requested value.",
 					},
 					"memory_gib": schema.Float64Attribute{
 						Computed:    true,


### PR DESCRIPTION
This commit updates TF descriptions to document that custom disk_iops values are only honored for AWS clusters during creation. For GCP and Azure, the value is always ignored. On update, disk_iops resets to the server-computed default for all cloud providers, including AWS. Users should omit this field to accept the server-side default.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
