### PR TITLE
[CC-35782]: suppress machine_type drift when vCPU count is unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `cockroach_user_role_grants` resource drift on refresh after creation. The Create function now uses the API response to populate state, matching the Update function's behavior.
 - Fixed `cockroach_user_role_grants` Read to use a direct user lookup instead of paginated full-org scan, preventing state removal on large orgs.
+- Fixed `machine_type` drift detection when the server converts instance families
+  with the same vCPU count. A warning is emitted advising users to update their
+  configuration.
 
 ## [1.19.0] - 2026-04-15
 

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -298,6 +298,9 @@ func (r *clusterResource) Schema(
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4. This attribute requires a feature flag to be enabled. It is recommended to leave this empty and use `num_virtual_cpus` to control the machine type.",
+						PlanModifiers: []planmodifier.String{
+							SuppressMachineTypeDrift(),
+						},
 					},
 					"num_virtual_cpus": schema.Int64Attribute{
 						Optional:    true,
@@ -1418,6 +1421,8 @@ func sortRegionsByPlan(regions *[]client.Region, plan []Region) {
 // if available, is used to determine the sort order of the cluster's regions, as well as
 // special formatting of certain attribute values (e.g. "preview" for `cockroach_version`).
 // When reading a datasource or importing a resource, `plan` will be nil.
+// For Read calls, the previous state is passed as `plan` so that machine_type
+// drift can be detected and suppressed when the vCPU count is unchanged.
 func loadClusterToTerraformState(
 	ctx context.Context,
 	clusterObj *client.Cluster,
@@ -1530,6 +1535,35 @@ func loadClusterToTerraformState(
 			// plan, then we add it to the state. If it was null, we keep it
 			// as null.
 			state.DedicatedConfig.SupportsClusterVirtualization = plan.DedicatedConfig.SupportsClusterVirtualization
+
+			// If the plan (or previous state during Read) had a
+			// machine_type that differs from the API response but has
+			// the same vCPU count (e.g., m6i→m7g), preserve
+			// the previous value. A warning is emitted so users know
+			// the server converted the type.
+			if IsKnown(plan.DedicatedConfig.MachineType) {
+				planMT := plan.DedicatedConfig.MachineType.ValueString()
+				apiMT := clusterObj.Config.Dedicated.MachineType
+				if planMT != apiMT {
+					planVCPUs, planOk := extractVCPUCount(clusterObj.CloudProvider, planMT)
+					apiVCPUs, apiOk := extractVCPUCount(clusterObj.CloudProvider, apiMT)
+					if planOk && apiOk && planVCPUs == apiVCPUs {
+						state.DedicatedConfig.MachineType = plan.DedicatedConfig.MachineType
+						allDiags.AddWarning(
+							"Machine type converted by server",
+							fmt.Sprintf(
+								"The server is running machine_type %q instead of %q "+
+									"(same vCPU count: %d). Update your configuration "+
+									"to use %q to remove this warning.",
+								apiMT, planMT, planVCPUs, apiMT,
+							),
+						)
+					}
+					// If either machine type couldn't be parsed, fall through
+					// and let the API value remain in state. This ensures
+					// unrecognized formats surface as normal Terraform drift.
+				}
+			}
 		}
 	}
 

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -1994,6 +1994,224 @@ func TestIntegrationDedicatedClusterResource(t *testing.T) {
 	testDedicatedClusterResource(t, clusterName, true, scaleStep)
 }
 
+// TestIntegrationDedicatedClusterMachineTypeMigration validates that when the
+// server converts instance families with the same vCPU count, the provider
+// preserves the user's configured value in state rather than showing drift.
+func TestIntegrationDedicatedClusterMachineTypeMigration(t *testing.T) {
+	// The API returns a different instance family than what the user configured.
+	migratedCluster := client.Cluster{
+		Id:               uuid.Nil.String(),
+		Name:             "test-cluster",
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{
+				MachineType:    "m7g.xlarge",
+				NumVirtualCpus: 4,
+				StorageGib:     15,
+				MemoryGib:      8,
+			},
+		},
+		Regions: []client.Region{
+			{
+				Name:      "us-east-1",
+				NodeCount: 1,
+			},
+		},
+	}
+
+	t.Run("drift suppressed when vCPU count matches", func(t *testing.T) {
+		clusterName := fmt.Sprintf("%s-dedicated-mt-%s", tfTestPrefix, GenerateRandomString(3))
+		clusterID := migratedCluster.Id
+		migratedCluster.Name = clusterName
+		if os.Getenv(CockroachAPIKey) == "" {
+			os.Setenv(CockroachAPIKey, "fake")
+		}
+
+		ctrl := gomock.NewController(t)
+		s := mock_client.NewMockService(ctrl)
+		defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+			return s
+		})()
+
+		const resourceName = "cockroach_cluster.test"
+
+		s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+			Return(&migratedCluster, nil, nil)
+		s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+			Return(initialBackupConfig, httpOk, nil).AnyTimes()
+		s.EXPECT().GetCluster(gomock.Any(), clusterID).
+			Return(&migratedCluster, httpOk, nil).AnyTimes()
+		s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).
+			Return(&migratedCluster, httpOk, nil)
+
+		// Deletion
+		s.EXPECT().DeleteCluster(gomock.Any(), clusterID).
+			Return(nil, httpOk, nil)
+
+		configWithMachineType := func(machineType string) string {
+			return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+    name           = "%s"
+    cloud_provider = "AWS"
+    cockroach_version = "%s"
+    dedicated = {
+        machine_type = "%s"
+        storage_gib  = 15
+    }
+    regions = [{
+        name       = "us-east-1"
+        node_count = 1
+    }]
+}
+`, clusterName, minSupportedClusterMajorVersion, machineType)
+		}
+
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					PreConfig: func() {
+						traceMessageStep("create with m6i.xlarge, server returns m7g.xlarge")
+					},
+					Config: configWithMachineType("m6i.xlarge"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "dedicated.machine_type", "m6i.xlarge"),
+						resource.TestCheckResourceAttr(resourceName, "dedicated.num_virtual_cpus", "4"),
+					),
+				},
+				{
+					PreConfig: func() {
+						traceMessageStep("re-apply same config, no changes expected")
+					},
+					Config: configWithMachineType("m6i.xlarge"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "dedicated.machine_type", "m6i.xlarge"),
+					),
+				},
+				{
+					PreConfig: func() {
+						traceMessageStep("user updates config to m7g.xlarge")
+					},
+					Config: configWithMachineType("m7g.xlarge"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, "dedicated.machine_type", "m7g.xlarge"),
+						resource.TestCheckResourceAttr(resourceName, "dedicated.num_virtual_cpus", "4"),
+					),
+				},
+			},
+		})
+
+		// Verify the warning diagnostic directly. The terraform test framework
+		// doesn't expose warnings, so we call loadClusterToTerraformState
+		// to check the content.
+		ctx := context.Background()
+		plan := &CockroachCluster{
+			DedicatedConfig: &DedicatedClusterConfig{
+				MachineType: types.StringValue("m6i.xlarge"),
+			},
+		}
+		var state CockroachCluster
+		diags := loadClusterToTerraformState(ctx, &migratedCluster, nil, &state, plan)
+
+		require.False(t, diags.HasError(), "expected no errors, got: %v", diags.Errors())
+		require.True(t, diags.WarningsCount() > 0, "expected a warning diagnostic for machine type drift")
+
+		found := false
+		for _, d := range diags {
+			if d.Summary() == "Machine type converted by server" {
+				found = true
+				require.Contains(t, d.Detail(), "m7g.xlarge")
+				require.Contains(t, d.Detail(), "m6i.xlarge")
+				require.Contains(t, d.Detail(), "same vCPU count: 4")
+				break
+			}
+		}
+		require.True(t, found, "expected warning with summary 'Machine type converted by server'")
+		require.Equal(t, "m6i.xlarge", state.DedicatedConfig.MachineType.ValueString())
+	})
+
+	t.Run("drift not suppressed when vCPU counts differ", func(t *testing.T) {
+		clusterName := fmt.Sprintf("%s-dedicated-mt-err-%s", tfTestPrefix, GenerateRandomString(3))
+		clusterID := migratedCluster.Id
+		if os.Getenv(CockroachAPIKey) == "" {
+			os.Setenv(CockroachAPIKey, "fake")
+		}
+
+		ctrl := gomock.NewController(t)
+		s := mock_client.NewMockService(ctrl)
+		defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+			return s
+		})()
+
+		// Server returns a different vCPU count than configured.
+		differentVCPUCluster := client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{
+					MachineType:    "m7g.2xlarge",
+					NumVirtualCpus: 8,
+					StorageGib:     15,
+					MemoryGib:      16,
+				},
+			},
+			Regions: []client.Region{
+				{
+					Name:      "us-east-1",
+					NodeCount: 1,
+				},
+			},
+		}
+
+		s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+			Return(&differentVCPUCluster, nil, nil)
+		s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+			Return(initialBackupConfig, httpOk, nil).AnyTimes()
+		s.EXPECT().GetCluster(gomock.Any(), clusterID).
+			Return(&differentVCPUCluster, httpOk, nil).AnyTimes()
+		s.EXPECT().DeleteCluster(gomock.Any(), clusterID).
+			Return(nil, httpOk, nil)
+
+		resource.Test(t, resource.TestCase{
+			IsUnitTest:               true,
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					PreConfig: func() {
+						traceMessageStep("create with m6i.xlarge, server returns m7g.2xlarge (different vCPUs)")
+					},
+					Config: fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+    name           = "%s"
+    cloud_provider = "AWS"
+    cockroach_version = "%s"
+    dedicated = {
+        machine_type = "m6i.xlarge"
+        storage_gib  = 15
+    }
+    regions = [{
+        name       = "us-east-1"
+        node_count = 1
+    }]
+}
+`, clusterName, minSupportedClusterMajorVersion),
+					ExpectError: regexp.MustCompile(`Provider produced inconsistent result after apply`),
+				},
+			},
+		})
+	})
+}
+
 // TestAccDedicatedAWSClusterS3VpcEndpointId is an acceptance test that creates
 // a real AWS Advanced cluster and verifies that s3_vpc_endpoint_id is populated.
 func TestAccDedicatedAWSClusterS3VpcEndpointId(t *testing.T) {

--- a/internal/provider/machine_type_plan_modifier.go
+++ b/internal/provider/machine_type_plan_modifier.go
@@ -1,0 +1,119 @@
+package provider
+
+import (
+	"context"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/v7/pkg/client"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// azureVCPUCountRE extracts the vCPU count from Azure machine types.
+// See https://learn.microsoft.com/en-us/azure/virtual-machines/vm-naming-conventions
+// Format: Standard_[Family][Subfamily]*[vCPUs]..., e.g. "Standard_D4s_v3" → 4.
+var azureVCPUCountRE = regexp.MustCompile(`^Standard_[A-Z]+(\d+)`)
+
+// awsSizeToVCPUs maps AWS instance size suffixes to vCPU counts.
+var awsSizeToVCPUs = map[string]int{
+	"medium":   1,
+	"large":    2,
+	"xlarge":   4,
+	"2xlarge":  8,
+	"4xlarge":  16,
+	"8xlarge":  32,
+	"9xlarge":  36,
+	"12xlarge": 48,
+	"16xlarge": 64,
+	"18xlarge": 72,
+	"24xlarge": 96,
+}
+
+// SuppressMachineTypeDrift returns a plan modifier for the machine_type
+// attribute. When the user does not set machine_type in config (using
+// num_virtual_cpus instead), it acts as UseStateForUnknown to prevent
+// "(known after apply)" noise.
+//
+// Drift suppression for instance family migrations is handled in
+// loadClusterToTerraformState, which preserves the previous
+// state value when the vCPU count is unchanged. This allows explicit user
+// changes to always reach the server.
+func SuppressMachineTypeDrift() planmodifier.String {
+	return machineTypeDriftSuppressor{}
+}
+
+type machineTypeDriftSuppressor struct{}
+
+func (m machineTypeDriftSuppressor) Description(_ context.Context) string {
+	return "Uses state value for machine_type when not set in config (num_virtual_cpus users)."
+}
+
+func (m machineTypeDriftSuppressor) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m machineTypeDriftSuppressor) PlanModifyString(
+	_ context.Context,
+	req planmodifier.StringRequest,
+	resp *planmodifier.StringResponse,
+) {
+	// No state (creation): nothing to do.
+	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+		return
+	}
+
+	// Config is null (user uses num_virtual_cpus, not machine_type).
+	// Use state value to prevent "(known after apply)" noise.
+	if req.ConfigValue.IsNull() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+}
+
+// extractVCPUCount extracts the vCPU count from a machine type string using
+// the cloud provider to determine the format. Returns (0, false) if the
+// machine type cannot be parsed.
+func extractVCPUCount(cloudProvider client.CloudProviderType, machineType string) (int, bool) {
+	switch cloudProvider {
+	case client.CLOUDPROVIDERTYPE_AWS:
+		// See https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-type-names.html
+		// Format: [family][generation][attributes].[size], e.g. "m6i.xlarge" → 4.
+		parts := strings.SplitN(machineType, ".", 2)
+		if len(parts) != 2 {
+			return 0, false
+		}
+		vcpus, ok := awsSizeToVCPUs[parts[1]]
+		return vcpus, ok
+
+	case client.CLOUDPROVIDERTYPE_GCP:
+		// See https://docs.cloud.google.com/compute/docs/machine-resource
+		// Format: [family]-[type]-[vCPUs], e.g. "n2-standard-4" → 4.
+		parts := strings.Split(machineType, "-")
+		if len(parts) < 3 {
+			return 0, false
+		}
+		n, err := strconv.Atoi(parts[len(parts)-1])
+		if err != nil || n <= 0 {
+			return 0, false
+		}
+		return n, true
+
+	case client.CLOUDPROVIDERTYPE_AZURE:
+		matches := azureVCPUCountRE.FindStringSubmatch(machineType)
+		if len(matches) != 2 {
+			return 0, false
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err != nil || n <= 0 {
+			return 0, false
+		}
+		return n, true
+
+	default:
+		return 0, false
+	}
+}
+
+// Compile-time check that machineTypeDriftSuppressor implements the interface.
+var _ planmodifier.String = machineTypeDriftSuppressor{}

--- a/internal/provider/machine_type_plan_modifier_test.go
+++ b/internal/provider/machine_type_plan_modifier_test.go
@@ -1,0 +1,138 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/v7/pkg/client"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractVCPUCount(t *testing.T) {
+	tests := []struct {
+		name          string
+		cloudProvider client.CloudProviderType
+		machineType   string
+		wantVCPUs     int
+		wantOk        bool
+	}{
+		// AWS
+		{name: "aws m6i.medium", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.medium", wantVCPUs: 1, wantOk: true},
+		{name: "aws m6i.large", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.large", wantVCPUs: 2, wantOk: true},
+		{name: "aws m6i.xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.xlarge", wantVCPUs: 4, wantOk: true},
+		{name: "aws m7g.xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m7g.xlarge", wantVCPUs: 4, wantOk: true},
+		{name: "aws m6i.2xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.2xlarge", wantVCPUs: 8, wantOk: true},
+		{name: "aws m7g.2xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m7g.2xlarge", wantVCPUs: 8, wantOk: true},
+		{name: "aws m6i.4xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.4xlarge", wantVCPUs: 16, wantOk: true},
+		{name: "aws m6i.8xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.8xlarge", wantVCPUs: 32, wantOk: true},
+		{name: "aws m6i.12xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.12xlarge", wantVCPUs: 48, wantOk: true},
+		{name: "aws m6i.16xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.16xlarge", wantVCPUs: 64, wantOk: true},
+		{name: "aws m6i.24xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.24xlarge", wantVCPUs: 96, wantOk: true},
+		{name: "aws c5.xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "c5.xlarge", wantVCPUs: 4, wantOk: true},
+		{name: "aws r6i.xlarge", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "r6i.xlarge", wantVCPUs: 4, wantOk: true},
+		{name: "aws m6i.metal", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.metal", wantVCPUs: 0, wantOk: false},
+		{name: "aws unknown size", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "m6i.foo", wantVCPUs: 0, wantOk: false},
+
+		// GCP
+		{name: "gcp n2-standard-4", cloudProvider: client.CLOUDPROVIDERTYPE_GCP, machineType: "n2-standard-4", wantVCPUs: 4, wantOk: true},
+		{name: "gcp n2-standard-8", cloudProvider: client.CLOUDPROVIDERTYPE_GCP, machineType: "n2-standard-8", wantVCPUs: 8, wantOk: true},
+		{name: "gcp n2-standard-16", cloudProvider: client.CLOUDPROVIDERTYPE_GCP, machineType: "n2-standard-16", wantVCPUs: 16, wantOk: true},
+		{name: "gcp c3-standard-4", cloudProvider: client.CLOUDPROVIDERTYPE_GCP, machineType: "c3-standard-4", wantVCPUs: 4, wantOk: true},
+		{name: "gcp n2-highmem-8", cloudProvider: client.CLOUDPROVIDERTYPE_GCP, machineType: "n2-highmem-8", wantVCPUs: 8, wantOk: true},
+
+		// Azure
+		{name: "azure Standard_D4s_v3", cloudProvider: client.CLOUDPROVIDERTYPE_AZURE, machineType: "Standard_D4s_v3", wantVCPUs: 4, wantOk: true},
+		{name: "azure Standard_D8s_v3", cloudProvider: client.CLOUDPROVIDERTYPE_AZURE, machineType: "Standard_D8s_v3", wantVCPUs: 8, wantOk: true},
+		{name: "azure Standard_D16s_v3", cloudProvider: client.CLOUDPROVIDERTYPE_AZURE, machineType: "Standard_D16s_v3", wantVCPUs: 16, wantOk: true},
+		{name: "azure Standard_E4s_v4", cloudProvider: client.CLOUDPROVIDERTYPE_AZURE, machineType: "Standard_E4s_v4", wantVCPUs: 4, wantOk: true},
+
+		// Unrecognized
+		{name: "empty string", cloudProvider: client.CLOUDPROVIDERTYPE_AWS, machineType: "", wantVCPUs: 0, wantOk: false},
+		{name: "unknown provider", cloudProvider: "UNKNOWN", machineType: "m6i.xlarge", wantVCPUs: 0, wantOk: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vcpus, ok := extractVCPUCount(tt.cloudProvider, tt.machineType)
+			require.Equal(t, tt.wantOk, ok, "ok mismatch for %s", tt.machineType)
+			if ok {
+				require.Equal(t, tt.wantVCPUs, vcpus, "vcpu mismatch for %s", tt.machineType)
+			}
+		})
+	}
+}
+
+func TestSuppressMachineTypeDrift(t *testing.T) {
+	ctx := context.Background()
+	modifier := SuppressMachineTypeDrift()
+
+	tests := []struct {
+		name         string
+		configValue  types.String
+		stateValue   types.String
+		planValue    types.String
+		expectedPlan types.String
+		description  string
+	}{
+		{
+			name:         "create - null state",
+			configValue:  types.StringValue("m6i.xlarge"),
+			stateValue:   types.StringNull(),
+			planValue:    types.StringValue("m6i.xlarge"),
+			expectedPlan: types.StringValue("m6i.xlarge"),
+			description:  "On create, state is null, plan should pass through unchanged",
+		},
+		{
+			name:         "no drift - config equals state",
+			configValue:  types.StringValue("m6i.xlarge"),
+			stateValue:   types.StringValue("m6i.xlarge"),
+			planValue:    types.StringValue("m6i.xlarge"),
+			expectedPlan: types.StringValue("m6i.xlarge"),
+			description:  "No drift, plan should remain unchanged",
+		},
+		{
+			name:         "config differs from state - diff allowed",
+			configValue:  types.StringValue("m6i.xlarge"),
+			stateValue:   types.StringValue("m7g.xlarge"),
+			planValue:    types.StringValue("m6i.xlarge"),
+			expectedPlan: types.StringValue("m6i.xlarge"),
+			description:  "Config differs from state, diff passes through to server",
+		},
+		{
+			name:         "different vcpu - diff allowed",
+			configValue:  types.StringValue("m6i.xlarge"),
+			stateValue:   types.StringValue("m7g.2xlarge"),
+			planValue:    types.StringValue("m6i.xlarge"),
+			expectedPlan: types.StringValue("m6i.xlarge"),
+			description:  "Different vCPUs (4 vs 8), diff should be allowed",
+		},
+		{
+			name:         "null config - uses state value",
+			configValue:  types.StringNull(),
+			stateValue:   types.StringValue("m7g.xlarge"),
+			planValue:    types.StringUnknown(),
+			expectedPlan: types.StringValue("m7g.xlarge"),
+			description:  "User uses num_virtual_cpus, machine_type should use state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := planmodifier.StringRequest{
+				ConfigValue: tt.configValue,
+				StateValue:  tt.stateValue,
+				PlanValue:   tt.planValue,
+			}
+			resp := &planmodifier.StringResponse{
+				PlanValue: tt.planValue,
+			}
+
+			modifier.PlanModifyString(ctx, req, resp)
+
+			require.Equal(t, tt.expectedPlan, resp.PlanValue, tt.description)
+			require.False(t, resp.Diagnostics.HasError(), "unexpected diagnostics error")
+		})
+	}
+}


### PR DESCRIPTION
When the server converts a cluster's instance family while preserving the same vCPU count, the provider no longer reports spurious diffs or "Provider produced inconsistent result" errors. A custom plan modifier on `machine_type` handles the `num_virtual_cpus` only case, and `loadClusterToTerraformState` preserves the plan value when vCPU counts match, emitting a warning so users know to update their configuration. 

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`) - Not required
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [x] Example(s) - Not required


**Screenshots**

Before:
<img width="1521" height="169" alt="Pasted Graphic 28" src="https://github.com/user-attachments/assets/479136a2-896d-41e8-ae85-e4a64e51fe6d" />

After:
![BFA8657E-DE0F-4F7D-97CF-2BA47E273FF4_1_201_a](https://github.com/user-attachments/assets/e357e563-8104-47d7-9137-5cbdc6393239)

