### PR TITLE
[CC-34727] Add s3_vpc_endpoint_id to cluster regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `s3_vpc_endpoint_id` computed attribute to cluster regions, exposing the AWS S3 VPC gateway endpoint ID for configuring S3 bucket policies. Only populated for Advanced clusters on AWS.
+
 ## [1.19.0] - 2026-04-15
 
 ### Changed

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -120,6 +120,7 @@ Read-Only:
 - `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
 - `primary` (Boolean) Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.
 - `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
+- `s3_vpc_endpoint_id` (String) The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -135,6 +135,7 @@ Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
 - `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
+- `s3_vpc_endpoint_id` (String) The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/docs/resources/cmek.md
+++ b/docs/resources/cmek.md
@@ -89,6 +89,7 @@ Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
 - `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
+- `s3_vpc_endpoint_id` (String) The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.
 - `sql_dns` (String) DNS name of the cluster's SQL interface. Used to connect to the cluster with IP allowlisting.
 - `ui_dns` (String) DNS name used when connecting to the DB Console for the cluster.
 

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -209,6 +209,10 @@ func (d *clusterDataSource) Schema(
 							Computed:    true,
 							Description: "Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.",
 						},
+						"s3_vpc_endpoint_id": schema.StringAttribute{
+							Computed:    true,
+							Description: "The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.",
+						},
 					},
 				},
 			},

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -113,6 +113,10 @@ var regionSchema = schema.NestedAttributeObject{
 			Computed:    true,
 			Description: "Set to true to mark this region as the primary for a serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.",
 		},
+		"s3_vpc_endpoint_id": schema.StringAttribute{
+			Computed:    true,
+			Description: "The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.",
+		},
 	},
 }
 
@@ -1615,6 +1619,7 @@ func getManagedRegions(apiRegions *[]client.Region, plan []Region) []Region {
 				PrivateEndpointDns: types.StringValue(x.PrivateEndpointDns),
 				NodeCount:          types.Int64Value(int64(x.NodeCount)),
 				Primary:            types.BoolValue(x.GetPrimary()),
+				S3VpcEndpointId:    types.StringValue(x.GetS3VpcEndpointId()),
 			}
 			regions = append(regions, rg)
 		}

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -1994,6 +1994,136 @@ func TestIntegrationDedicatedClusterResource(t *testing.T) {
 	testDedicatedClusterResource(t, clusterName, true, scaleStep)
 }
 
+// TestAccDedicatedAWSClusterS3VpcEndpointId is an acceptance test that creates
+// a real AWS Advanced cluster and verifies that s3_vpc_endpoint_id is populated.
+func TestAccDedicatedAWSClusterS3VpcEndpointId(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("%s-aws-vpce-%s", tfTestPrefix, GenerateRandomString(3))
+
+	cfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "AWS"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib      = 35
+    num_virtual_cpus = 4
+  }
+  regions = [{
+    name       = "us-east-1"
+    node_count = 3
+  }]
+}
+
+data "cockroach_cluster" "test" {
+  id = cockroach_cluster.test.id
+}
+`, clusterName)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               false,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCockroachClusterExists("cockroach_cluster.test"),
+					resource.TestMatchResourceAttr("cockroach_cluster.test", "regions.0.s3_vpc_endpoint_id", regexp.MustCompile(`^vpce-`)),
+					resource.TestMatchResourceAttr("data.cockroach_cluster.test", "regions.0.s3_vpc_endpoint_id", regexp.MustCompile(`^vpce-`)),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedAWSClusterS3VpcEndpointId validates that
+// s3_vpc_endpoint_id is populated for AWS Advanced clusters and
+// accessible on both the resource and data source.
+func TestIntegrationDedicatedAWSClusterS3VpcEndpointId(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-aws-vpce-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	cluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{
+				NumVirtualCpus: 4,
+				StorageGib:     35,
+				MemoryGib:      16,
+			},
+		},
+		Regions: []client.Region{
+			{
+				Name:            "us-east-1",
+				SqlDns:          "test.aws-us-east-1.crdb.io",
+				UiDns:           "admin-test.aws-us-east-1.crdb.io",
+				InternalDns:     "internal-test.aws-us-east-1.crdb.io",
+				NodeCount:       3,
+				S3VpcEndpointId: ptr("vpce-0abc123def456"),
+			},
+		},
+	}
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).
+		Return(&cluster, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).
+		Return(&cluster, httpOk, nil).AnyTimes()
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID)
+
+	cfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "AWS"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib     = 35
+    num_virtual_cpus = 4
+  }
+  regions = [{
+    name       = "us-east-1"
+    node_count = 3
+  }]
+}
+
+data "cockroach_cluster" "test" {
+  id = cockroach_cluster.test.id
+}
+`, clusterName)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.s3_vpc_endpoint_id", "vpce-0abc123def456"),
+					resource.TestCheckResourceAttr("data.cockroach_cluster.test", "regions.0.s3_vpc_endpoint_id", "vpce-0abc123def456"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "cloud_provider", "AWS"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "plan", "ADVANCED"),
+				),
+			},
+		},
+	})
+}
+
 // TestIntegrationDedicatedClusterBYOC validates that BYOC details are passed in
 // the create request and are reflected in state.
 func TestIntegrationDedicatedClusterBYOC(t *testing.T) {
@@ -2241,7 +2371,11 @@ func testCheckCockroachClusterExists(resourceName string) resource.TestCheckFunc
 }
 
 func getTestDedicatedClusterResourceConfig(
-	name, version string, finalize bool, vcpus int, deleteProtectionEnabled *bool, privateEndpointServicesEnabled bool,
+	name, version string,
+	finalize bool,
+	vcpus int,
+	deleteProtectionEnabled *bool,
+	privateEndpointServicesEnabled bool,
 ) string {
 	var deleteProtectionConfig string
 	if deleteProtectionEnabled != nil {
@@ -2433,6 +2567,61 @@ func TestSortRegionsByPlan(t *testing.T) {
 		}
 		// We really just want to make sure it doesn't panic here.
 		sortRegionsByPlan(&regions, plan)
+	})
+}
+
+func TestGetManagedRegionsS3VpcEndpointId(t *testing.T) {
+	t.Run("AWS cluster with s3_vpc_endpoint_id", func(t *testing.T) {
+		vpceid := "vpce-0abc123def456"
+		regions := []client.Region{
+			{
+				Name:               "us-east-1",
+				SqlDns:             "test.aws-us-east-1.crdb.io",
+				UiDns:              "admin-test.aws-us-east-1.crdb.io",
+				InternalDns:        "internal-test.aws-us-east-1.crdb.io",
+				PrivateEndpointDns: "",
+				NodeCount:          3,
+				S3VpcEndpointId:    &vpceid,
+			},
+		}
+		plan := []Region{
+			{Name: types.StringValue("us-east-1")},
+		}
+		result := getManagedRegions(&regions, plan)
+		require.Len(t, result, 1)
+		require.Equal(t, "vpce-0abc123def456", result[0].S3VpcEndpointId.ValueString())
+	})
+
+	t.Run("GCP cluster without s3_vpc_endpoint_id", func(t *testing.T) {
+		regions := []client.Region{
+			{
+				Name:               "us-central1",
+				SqlDns:             "test.gcp-us-central1.crdb.io",
+				UiDns:              "admin-test.gcp-us-central1.crdb.io",
+				PrivateEndpointDns: "private-test.crdb.io",
+				NodeCount:          3,
+			},
+		}
+		plan := []Region{
+			{Name: types.StringValue("us-central1")},
+		}
+		result := getManagedRegions(&regions, plan)
+		require.Len(t, result, 1)
+		require.Equal(t, "", result[0].S3VpcEndpointId.ValueString())
+	})
+
+	t.Run("Data source import with no plan", func(t *testing.T) {
+		vpceid := "vpce-0def456abc789"
+		regions := []client.Region{
+			{
+				Name:            "us-west-2",
+				NodeCount:       3,
+				S3VpcEndpointId: &vpceid,
+			},
+		}
+		result := getManagedRegions(&regions, nil)
+		require.Len(t, result, 1)
+		require.Equal(t, "vpce-0def456abc789", result[0].S3VpcEndpointId.ValueString())
 	})
 }
 

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -39,6 +39,7 @@ type Region struct {
 	PrivateEndpointDns types.String `tfsdk:"private_endpoint_dns"`
 	NodeCount          types.Int64  `tfsdk:"node_count"`
 	Primary            types.Bool   `tfsdk:"primary"`
+	S3VpcEndpointId    types.String `tfsdk:"s3_vpc_endpoint_id"`
 }
 
 type DedicatedClusterConfig struct {


### PR DESCRIPTION
This commit adds the `s3_vpc_endpoint_id` computed attribute to cluster regions, exposing the AWS S3 VPC gateway endpoint ID. Customers can use this to configure S3 bucket policies that restrict access to traffic from their CockroachDB cluster's VPC endpoint. Only populated for Advanced clusters on AWS.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s) - N/A (computed field, documented in generated docs)