### PR TITLE
Fix role grants Create to use API response for state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `s3_vpc_endpoint_id` computed attribute to cluster regions, exposing the AWS S3 VPC gateway endpoint ID for configuring S3 bucket policies. Only populated for Advanced clusters on AWS.
 
+### Fixed
+
+- Fixed `cockroach_user_role_grants` resource drift on refresh after creation. The Create function now uses the API response to populate state, matching the Update function's behavior.
+- Fixed `cockroach_user_role_grants` Read to use a direct user lookup instead of paginated full-org scan, preventing state removal on large orgs.
+
 ## [1.19.0] - 2026-04-15
 
 ### Changed

--- a/internal/provider/user_role_grants_resource.go
+++ b/internal/provider/user_role_grants_resource.go
@@ -29,8 +29,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-const roleGrantPaginationLimit = 100
-
 type userRoleGrantsResource struct {
 	provider *provider
 }
@@ -139,7 +137,7 @@ func (r *userRoleGrantsResource) Create(
 	setRoleRequest.SetRoles(roles)
 
 	traceAPICall("SetRolesForUser")
-	_, _, err = r.provider.service.SetRolesForUser(ctx, roleGrantSpec.UserId.ValueString(), &setRoleRequest)
+	apiResp, _, err := r.provider.service.SetRolesForUser(ctx, roleGrantSpec.UserId.ValueString(), &setRoleRequest)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error setting roles for user",
@@ -148,6 +146,7 @@ func (r *userRoleGrantsResource) Create(
 		return
 	}
 
+	loadRolesToTerraformState(roleGrantSpec.UserId.ValueString(), apiResp, &roleGrantSpec)
 	roleGrantSpec.ID = roleGrantSpec.UserId
 	diags = resp.State.Set(ctx, roleGrantSpec)
 	resp.Diagnostics.Append(diags...)
@@ -168,51 +167,34 @@ func (r *userRoleGrantsResource) Read(
 		return
 	}
 
-	// Since the state may have come from an import, we need to retrieve
-	// the actual user list and make sure this one is in there.
-	var page string
-	limit := int32(roleGrantPaginationLimit)
-
-	for {
-		options := &client.ListRoleGrantsOptions{
-			PaginationPage:  &page,
-			PaginationLimit: &limit,
-		}
-		traceAPICall("ListRoleGrants")
-		apiResp, _, err := r.provider.service.ListRoleGrants(ctx, options)
-		if err != nil {
-			resp.Diagnostics.AddError(
-				"Error listing user roles",
-				fmt.Sprintf("Unexpected error retrieving user roles: %s", formatAPIErrorMessage(err)),
-			)
-			return
-		}
-
-		for _, grant := range apiResp.GetGrants() {
-			if grant.GetUserId() == state.UserId.ValueString() {
-				loadListRolesToTerraformState(state.UserId.ValueString(), &grant, &state)
-				state.ID = state.UserId
-				diags = resp.State.Set(ctx, state)
-				resp.Diagnostics.Append(diags...)
-				return
-			}
-		}
-
-		pagination := apiResp.GetPagination()
-		if pagination.NextPage != nil && *pagination.NextPage != "" {
-			page = *pagination.NextPage
-		} else {
-			break
-		}
+	// Look up the user's roles directly by user ID.
+	traceAPICall("GetAllRolesForUser")
+	apiResp, _, err := r.provider.service.GetAllRolesForUser(ctx, state.UserId.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting user roles",
+			fmt.Sprintf("Unexpected error retrieving roles for user: %s", formatAPIErrorMessage(err)),
+		)
+		return
 	}
-	resp.Diagnostics.AddWarning(
-		"Couldn't find user.",
-		fmt.Sprintf(
-			"Could not find user with ID '%v'. Removing from state.",
-			state.UserId.ValueString(),
-		),
-	)
-	resp.State.RemoveResource(ctx)
+
+	roles := apiResp.GetRoles()
+	if len(roles) == 0 {
+		resp.Diagnostics.AddWarning(
+			"Couldn't find user.",
+			fmt.Sprintf(
+				"Could not find any roles for user with ID '%v'. Removing from state.",
+				state.UserId.ValueString(),
+			),
+		)
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	loadRolesToTerraformState(state.UserId.ValueString(), apiResp, &state)
+	state.ID = state.UserId
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
 }
 
 func (r *userRoleGrantsResource) Update(

--- a/internal/provider/user_role_grants_resource_test.go
+++ b/internal/provider/user_role_grants_resource_test.go
@@ -59,37 +59,6 @@ func TestIntegrationRoleGrantsResource(t *testing.T) {
 	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
 		return s
 	})()
-	listResponse := client.ListRoleGrantsResponse{
-		Grants: &[]client.UserRoleGrants{
-			{
-				UserId: userId,
-				Roles: []client.BuiltInRole{
-					{
-						Name: client.ORGANIZATIONUSERROLETYPE_CLUSTER_ADMIN,
-						Resource: client.Resource{
-							Id:   nil,
-							Type: client.RESOURCETYPETYPE_ORGANIZATION,
-						},
-					},
-					{
-						Name: client.ORGANIZATIONUSERROLETYPE_ORG_ADMIN,
-						Resource: client.Resource{
-							Id:   nil,
-							Type: client.RESOURCETYPETYPE_ORGANIZATION,
-						},
-					},
-					{
-						Name: client.ORGANIZATIONUSERROLETYPE_ORG_MEMBER,
-						Resource: client.Resource{
-							Id:   nil,
-							Type: client.RESOURCETYPETYPE_ORGANIZATION,
-						},
-					},
-				},
-			},
-		},
-		Pagination: nil,
-	}
 
 	restrictedGetResponse := client.GetAllRolesForUserResponse{
 		Roles: &[]client.BuiltInRole{
@@ -131,18 +100,21 @@ func TestIntegrationRoleGrantsResource(t *testing.T) {
 
 	s.EXPECT().CreateServiceAccount(gomock.Any(), gomock.Any()).
 		Return(&serviceAccount, nil, nil)
+	// Create calls GetAllRolesForUser to check preexisting roles, then
+	// SetRolesForUser. After that, Read (via refresh plan and import)
+	// also calls GetAllRolesForUser directly instead of ListRoleGrants.
 	s.EXPECT().GetAllRolesForUser(gomock.Any(), userId).
 		Return(&restrictedGetResponse, nil, nil)
 	s.EXPECT().SetRolesForUser(gomock.Any(), userId, gomock.Any()).
-		Return(nil, nil, nil)
+		Return(&permissionedGetResponse, nil, nil)
+	// Called by: testRoleMembership checks (x3), step 1 refresh plan Read
+	// (x1), and step 2 import Read (x1) = 5 total.
 	s.EXPECT().GetAllRolesForUser(gomock.Any(), userId).
-		Return(&permissionedGetResponse, nil, nil).Times(3)
+		Return(&permissionedGetResponse, nil, nil).Times(5)
 	s.EXPECT().GetServiceAccount(gomock.Any(), serviceAccount.Id).
 		Return(&serviceAccount, &http.Response{Status: http.StatusText(http.StatusOK)}, nil)
-	s.EXPECT().ListRoleGrants(gomock.Any(), gomock.Any()).
-		Return(&listResponse, nil, nil).Times(2)
 	s.EXPECT().SetRolesForUser(gomock.Any(), userId, &client.CockroachCloudSetRolesForUserRequest{}).
-		Return(nil, nil, nil)
+		Return(&restrictedGetResponse, nil, nil)
 	s.EXPECT().DeleteServiceAccount(gomock.Any(), gomock.Any()).
 		Return(nil, nil, nil)
 
@@ -178,9 +150,7 @@ func testRoleResource(t *testing.T, useMock bool) {
 	})
 }
 
-func testRoleMembership(
-	resourceName, roleName string, hasRole bool,
-) resource.TestCheckFunc {
+func testRoleMembership(resourceName, roleName string, hasRole bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		p := testAccProvider.(*provider)
 		p.service = NewService(cl)


### PR DESCRIPTION
The Create function discarded the SetRolesForUser API  response and saved plan data directly to state. If the API normalized  anything (field ordering, defaults), state wouldn't match what Read  returns, causing drift. Fixed by capturing the response and calling  loadRolesToTerraformState, matching the Update function's existing behavior.                                                                     
                                                                              
The Read function used ListRoleGrants, a paginated endpoint that scans ALL users in the org, Then searched for the target user ID across pages. The managed-service PaginateLocal implementation uses binary search for page navigation on unsorted data, which can miss entries for orgs with 100+ users. When the user wasn't found, Read         removed the resource from state, causing Terraform to want to recreate it.                                                                           
                                                                                
Fixed by replacing the ListRoleGrants pagination loop with a direct GetAllRolesForUser(userId) call. This matches the approach already used by the singular user_role_grant resource.

The April 17 CC deploy likely added users/service accounts to the test organization (from MFA feature work), pushing the total past the 100 user pagination boundary where the binary search bug manifests. On April 15 there were fewer users, so the first page contained everyone and pagination wasn't needed.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`) (N/a no schema changes).
- [x] Integration test(s)
- [x] Acceptance test(s)
- [ ] Example(s) (N/a bug fix).
