### PR TITLE
Update CHANGELOG for v1.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.20.0] - 2026-04-22
+
 ### Added
 
 - Added `s3_vpc_endpoint_id` computed attribute to cluster regions, exposing the AWS S3 VPC gateway endpoint ID for configuring S3 bucket policies. Only populated for Advanced clusters on AWS.


### PR DESCRIPTION
This PR is for cutting the v.1.20.0 release.

**Commit checklist**
- [x] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [x] Acceptance test(s) (Pushing the v1.20.0 tag auto triggers all acceptance tests)
- [ ] Example(s)
