### PR TITLE
Add post test cleanup for orphaned acceptance test clusters

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -23,3 +23,11 @@ jobs:
         run: make testacc
         env:
           COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}
+          CLEANUP_TRACKING_FILE: ${{ runner.temp }}/created-clusters.txt
+
+      - name: Cleanup orphaned test clusters
+        if: always()
+        run: bash scripts/cleanup-test-clusters.sh
+        env:
+          COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}
+          CLEANUP_TRACKING_FILE: ${{ runner.temp }}/created-clusters.txt

--- a/.github/workflows/pre-release-ci.yaml
+++ b/.github/workflows/pre-release-ci.yaml
@@ -28,3 +28,11 @@ jobs:
         run: make testacc
         env:
           COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}
+          CLEANUP_TRACKING_FILE: ${{ runner.temp }}/created-clusters.txt
+
+      - name: Cleanup orphaned test clusters
+        if: always()
+        run: bash scripts/cleanup-test-clusters.sh
+        env:
+          COCKROACH_API_KEY: ${{ secrets.COCKROACH_API_KEY }}
+          CLEANUP_TRACKING_FILE: ${{ runner.temp }}/created-clusters.txt

--- a/Makefile
+++ b/Makefile
@@ -51,3 +51,6 @@ test:
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m -parallel 100
+
+cleanup-test-clusters:
+	bash scripts/cleanup-test-clusters.sh

--- a/internal/provider/cluster_tracking.go
+++ b/internal/provider/cluster_tracking.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2023 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/cockroachdb/cockroach-cloud-sdk-go/v7/pkg/client"
+)
+
+const clusterTrackingEnvVar = "CLEANUP_TRACKING_FILE"
+
+var (
+	trackingMu          sync.Mutex
+	trackingInitialized bool
+)
+
+func getTrackingFilePath() string {
+	return os.Getenv(clusterTrackingEnvVar)
+}
+
+// newTrackingService wraps a client.Service to track cluster creation and
+// deletion in a file. Returns the original service unwrapped if tracking
+// is not enabled (CLEANUP_TRACKING_FILE not set).
+func newTrackingService(inner client.Service) client.Service {
+	filePath := getTrackingFilePath()
+	if filePath == "" {
+		return inner
+	}
+
+	trackingMu.Lock()
+	if !trackingInitialized {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Tracking enabled: file=%s\n", filePath)
+		trackingInitialized = true
+	}
+	trackingMu.Unlock()
+
+	return &trackingService{Service: inner, filePath: filePath}
+}
+
+// trackingService wraps client.Service to intercept CreateCluster and
+// DeleteCluster calls, recording cluster IDs in a tracking file for
+// post-test cleanup.
+type trackingService struct {
+	client.Service
+	filePath string
+}
+
+func (s *trackingService) CreateCluster(
+	ctx context.Context, req *client.CreateClusterRequest,
+) (*client.Cluster, *http.Response, error) {
+	cluster, resp, err := s.Service.CreateCluster(ctx, req)
+	if err == nil && cluster != nil {
+		recordClusterCreation(s.filePath, cluster.GetId(), cluster.GetName())
+	}
+	return cluster, resp, err
+}
+
+func (s *trackingService) DeleteCluster(
+	ctx context.Context, clusterId string,
+) (*client.Cluster, *http.Response, error) {
+	cluster, resp, err := s.Service.DeleteCluster(ctx, clusterId)
+	if err == nil {
+		recordClusterDeletion(s.filePath, clusterId)
+	} else if resp != nil && resp.StatusCode == http.StatusNotFound {
+		recordClusterDeletion(s.filePath, clusterId)
+	}
+	return cluster, resp, err
+}
+
+// recordClusterCreation appends a cluster ID and name to the tracking file.
+// Best-effort: errors are logged but never fatal.
+func recordClusterCreation(filePath, id, name string) {
+	trackingMu.Lock()
+	defer trackingMu.Unlock()
+
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error opening tracking file: %s\n", err)
+		return
+	}
+	defer f.Close()
+
+	if _, err := fmt.Fprintf(f, "%s %s\n", id, name); err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error writing to tracking file: %s\n", err)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "[cluster-tracking] Created: id=%s name=%s\n", id, name)
+}
+
+// recordClusterDeletion removes a cluster ID from the tracking file.
+// Uses atomic write (temp file + rename) to avoid corruption if the
+// process is killed mid-write.
+// Best-effort: errors are logged but never fatal.
+func recordClusterDeletion(filePath, id string) {
+	trackingMu.Lock()
+	defer trackingMu.Unlock()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error reading tracking file: %s\n", err)
+		return
+	}
+
+	var remaining []string
+	removed := false
+	scanner := bufio.NewScanner(strings.NewReader(string(data)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, id+" ") || line == id {
+			removed = true
+			continue
+		}
+		remaining = append(remaining, line)
+	}
+
+	dir := filepath.Dir(filePath)
+	tmpFile, err := os.CreateTemp(dir, "tracking-*.tmp")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error creating temp file: %s\n", err)
+		return
+	}
+	tmpPath := tmpFile.Name()
+
+	content := ""
+	if len(remaining) > 0 {
+		content = strings.Join(remaining, "\n") + "\n"
+	}
+	if _, err := tmpFile.WriteString(content); err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error writing temp file: %s\n", err)
+		tmpFile.Close()
+		os.Remove(tmpPath)
+		return
+	}
+	if err := tmpFile.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error closing temp file: %s\n", err)
+		os.Remove(tmpPath)
+		return
+	}
+
+	if err := os.Rename(tmpPath, filePath); err != nil {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Error renaming temp file: %s\n", err)
+		os.Remove(tmpPath)
+		return
+	}
+
+	if removed {
+		fmt.Fprintf(os.Stderr, "[cluster-tracking] Deleted: id=%s\n", id)
+	}
+}

--- a/internal/provider/cluster_tracking.go
+++ b/internal/provider/cluster_tracking.go
@@ -32,30 +32,18 @@ import (
 const clusterTrackingEnvVar = "CLEANUP_TRACKING_FILE"
 
 var (
-	trackingMu          sync.Mutex
-	trackingInitialized bool
+	trackingMu      sync.Mutex
+	trackingLogOnce sync.Once
 )
 
-func getTrackingFilePath() string {
-	return os.Getenv(clusterTrackingEnvVar)
-}
-
-// newTrackingService wraps a client.Service to track cluster creation and
-// deletion in a file. Returns the original service unwrapped if tracking
-// is not enabled (CLEANUP_TRACKING_FILE not set).
-func newTrackingService(inner client.Service) client.Service {
-	filePath := getTrackingFilePath()
-	if filePath == "" {
-		return inner
-	}
-
-	trackingMu.Lock()
-	if !trackingInitialized {
+// newTrackingService wraps a client.Service to record cluster creation and
+// deletion to filePath. Intended for CI use only; provider.go gates
+// construction on the CLEANUP_TRACKING_FILE env var so this wrapper is
+// never instantiated when customers run the provider.
+func newTrackingService(inner client.Service, filePath string) client.Service {
+	trackingLogOnce.Do(func() {
 		fmt.Fprintf(os.Stderr, "[cluster-tracking] Tracking enabled: file=%s\n", filePath)
-		trackingInitialized = true
-	}
-	trackingMu.Unlock()
-
+	})
 	return &trackingService{Service: inner, filePath: filePath}
 }
 

--- a/internal/provider/cluster_tracking_test.go
+++ b/internal/provider/cluster_tracking_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2023 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestRecordClusterCreation_WritesToFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	recordClusterCreation(filePath, "id-1", "cluster-one")
+	recordClusterCreation(filePath, "id-2", "cluster-two")
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines, got %d: %q", len(lines), string(data))
+	}
+	if lines[0] != "id-1 cluster-one" {
+		t.Errorf("Expected first line 'id-1 cluster-one', got %q", lines[0])
+	}
+	if lines[1] != "id-2 cluster-two" {
+		t.Errorf("Expected second line 'id-2 cluster-two', got %q", lines[1])
+	}
+}
+
+func TestRecordClusterDeletion_RemovesFromFile(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	recordClusterCreation(filePath, "id-1", "cluster-one")
+	recordClusterCreation(filePath, "id-2", "cluster-two")
+	recordClusterCreation(filePath, "id-3", "cluster-three")
+
+	recordClusterDeletion(filePath, "id-2")
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines after deletion, got %d: %q", len(lines), string(data))
+	}
+	if lines[0] != "id-1 cluster-one" {
+		t.Errorf("Expected first line 'id-1 cluster-one', got %q", lines[0])
+	}
+	if lines[1] != "id-3 cluster-three" {
+		t.Errorf("Expected second line 'id-3 cluster-three', got %q", lines[1])
+	}
+}
+
+func TestRecordClusterDeletion_AllRemoved(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	recordClusterCreation(filePath, "id-1", "cluster-one")
+	recordClusterDeletion(filePath, "id-1")
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	content := strings.TrimSpace(string(data))
+	if content != "" {
+		t.Errorf("Expected empty file after all deletions, got %q", content)
+	}
+}
+
+func TestRecordClusterDeletion_NonexistentID(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	recordClusterCreation(filePath, "id-1", "cluster-one")
+	recordClusterDeletion(filePath, "id-nonexistent")
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("Expected 1 line (original entry preserved), got %d: %q", len(lines), string(data))
+	}
+	if lines[0] != "id-1 cluster-one" {
+		t.Errorf("Expected 'id-1 cluster-one', got %q", lines[0])
+	}
+}
+
+func TestRecordClusterDeletion_FileDoesNotExist(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "nonexistent.txt")
+
+	recordClusterDeletion(filePath, "id-1")
+}
+
+func TestRecordClusterCreation_ConcurrentWrites(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	var wg sync.WaitGroup
+	count := 20
+	for i := 0; i < count; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			id := strings.Replace(strings.Repeat("0", 8), "0", string(rune('a'+n%26)), -1)
+			recordClusterCreation(filePath, id, "cluster-"+id)
+		}(i)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != count {
+		t.Errorf("Expected %d lines from concurrent writes, got %d", count, len(lines))
+	}
+}
+
+func TestRecordClusterCreationAndDeletion_ConcurrentMixed(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+
+	for i := 0; i < 10; i++ {
+		recordClusterCreation(
+			filePath,
+			strings.Replace("id-00", "00", strings.Repeat(string(rune('0'+i)), 2), 1),
+			"cluster-"+string(rune('a'+i)),
+		)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i += 2 {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			recordClusterDeletion(
+				filePath,
+				strings.Replace("id-00", "00", strings.Repeat(string(rune('0'+n)), 2), 1),
+			)
+		}(i)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("Failed to read tracking file: %s", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 5 {
+		t.Errorf("Expected 5 lines after deleting 5 of 10, got %d: %q", len(lines), string(data))
+	}
+}
+
+func TestNewTrackingService_DisabledWhenNoEnvVar(t *testing.T) {
+	t.Setenv(clusterTrackingEnvVar, "")
+	inner := NewService(nil)
+	svc := newTrackingService(inner)
+	if _, ok := svc.(*trackingService); ok {
+		t.Error("Expected unwrapped service when tracking is disabled")
+	}
+}
+
+func TestNewTrackingService_EnabledWhenEnvVarSet(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "tracking.txt")
+	t.Setenv(clusterTrackingEnvVar, filePath)
+	trackingInitialized = false
+
+	inner := NewService(nil)
+	svc := newTrackingService(inner)
+	ts, ok := svc.(*trackingService)
+	if !ok {
+		t.Fatal("Expected trackingService wrapper when tracking is enabled")
+	}
+	if ts.filePath != filePath {
+		t.Errorf("Expected filePath %q, got %q", filePath, ts.filePath)
+	}
+}

--- a/internal/provider/cluster_tracking_test.go
+++ b/internal/provider/cluster_tracking_test.go
@@ -184,26 +184,15 @@ func TestRecordClusterCreationAndDeletion_ConcurrentMixed(t *testing.T) {
 	}
 }
 
-func TestNewTrackingService_DisabledWhenNoEnvVar(t *testing.T) {
-	t.Setenv(clusterTrackingEnvVar, "")
-	inner := NewService(nil)
-	svc := newTrackingService(inner)
-	if _, ok := svc.(*trackingService); ok {
-		t.Error("Expected unwrapped service when tracking is disabled")
-	}
-}
-
-func TestNewTrackingService_EnabledWhenEnvVarSet(t *testing.T) {
+func TestNewTrackingService_WrapsInner(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "tracking.txt")
-	t.Setenv(clusterTrackingEnvVar, filePath)
-	trackingInitialized = false
 
 	inner := NewService(nil)
-	svc := newTrackingService(inner)
+	svc := newTrackingService(inner, filePath)
 	ts, ok := svc.(*trackingService)
 	if !ok {
-		t.Fatal("Expected trackingService wrapper when tracking is enabled")
+		t.Fatal("Expected trackingService wrapper")
 	}
 	if ts.filePath != filePath {
 		t.Errorf("Expected filePath %q, got %q", filePath, ts.filePath)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,7 +113,7 @@ func (p *provider) Configure(
 	cfg.HTTPClient = httpClient.StandardClient()
 
 	cl := client.NewClient(cfg)
-	p.service = NewService(cl)
+	p.service = newTrackingService(NewService(cl))
 	resp.ResourceData = p
 	resp.DataSourceData = p
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,7 +113,11 @@ func (p *provider) Configure(
 	cfg.HTTPClient = httpClient.StandardClient()
 
 	cl := client.NewClient(cfg)
-	p.service = newTrackingService(NewService(cl))
+	svc := NewService(cl)
+	if filePath := os.Getenv(clusterTrackingEnvVar); filePath != "" {
+		svc = newTrackingService(svc, filePath)
+	}
+	p.service = svc
 	resp.ResourceData = p
 	resp.DataSourceData = p
 

--- a/scripts/cleanup-test-clusters.sh
+++ b/scripts/cleanup-test-clusters.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub Actions log annotations.
+log_error()    { echo "::error title=${2:-Error}::$1"; }
+log_warning()  { echo "::warning title=${2:-Warning}::$1"; }
+log_notice()   { echo "::notice title=${2:-Notice}::$1"; }
+log_group()    { echo "::group::$*"; }
+log_endgroup() { echo "::endgroup::"; }
+
+# Write to the GitHub Actions step summary (no-op outside CI).
+write_summary() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$1" >> "$GITHUB_STEP_SUMMARY"
+  fi
+}
+
+# Verify required commands are available.
+for cmd in jq curl; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log_error "Required command not found: ${cmd}" "Missing Dependency"
+    write_summary "### Cluster Cleanup"$'\n'"**Error:** Required command \`${cmd}\` not found."
+    exit 1
+  fi
+done
+
+TRACKING_FILE="${CLEANUP_TRACKING_FILE:-}"
+API_URL="${COCKROACH_SERVER:-https://cockroachlabs.cloud}"
+DRY_RUN="${DRY_RUN:-0}"
+MAX_RETRIES=3
+RETRY_DELAY=5
+
+if [[ -z "${COCKROACH_API_KEY:-}" ]]; then
+  log_error "COCKROACH_API_KEY is not set" "Configuration"
+  write_summary "### Cluster Cleanup"$'\n'"**Error:** COCKROACH_API_KEY is not set."
+  exit 1
+fi
+
+auth_header="Authorization: Bearer ${COCKROACH_API_KEY}"
+response_file=$(mktemp)
+
+cleanup_temp_files() {
+  rm -f "$response_file"
+  if [[ -n "$TRACKING_FILE" && -f "$TRACKING_FILE" ]]; then
+    rm -f "$TRACKING_FILE"
+    echo "Removed tracking file: ${TRACKING_FILE}"
+  fi
+}
+trap cleanup_temp_files EXIT
+
+echo "=== Cleanup Orphaned Test Clusters ==="
+echo "API URL: ${API_URL}"
+echo "Tracking file: ${TRACKING_FILE:-<not set>}"
+echo "Dry run: ${DRY_RUN}"
+echo ""
+
+# delete_cluster deletes a single cluster by ID with retries.
+# Arguments: $1=id $2=name
+# Returns: 0 on success, 1 on failure.
+delete_cluster() {
+  local id="$1"
+  local name="$2"
+
+  for attempt in $(seq 1 "$MAX_RETRIES"); do
+    echo "Deleting ${name} (${id}) [attempt ${attempt}/${MAX_RETRIES}]..."
+
+    local http_code
+    http_code=$(curl -s -o "$response_file" -w "%{http_code}" \
+      -X DELETE \
+      -H "$auth_header" \
+      -H "Content-Type: application/json" \
+      "${API_URL}/api/v1/clusters/${id}")
+
+    if [[ "$http_code" == "200" || "$http_code" == "404" ]]; then
+      echo "  OK (HTTP ${http_code})"
+      return 0
+    else
+      log_error "Failed to delete ${name} (${id}): HTTP ${http_code}" "Cluster Deletion"
+      cat "$response_file" 2>/dev/null || true
+      echo ""
+      if [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
+        echo "  Retrying in ${RETRY_DELAY}s..."
+        sleep "$RETRY_DELAY"
+      fi
+    fi
+  done
+
+  log_error "Giving up on ${name} (${id}) after ${MAX_RETRIES} attempts" "Cluster Deletion"
+  return 1
+}
+
+# fetch_cluster fetches a single cluster by ID.
+# Arguments: $1=id
+# Outputs the cluster JSON to stdout. Returns non-zero on failure.
+fetch_cluster() {
+  local id="$1"
+  curl -sf -H "$auth_header" "${API_URL}/api/v1/clusters/${id}"
+}
+
+# Exit early if no tracking file is configured or present.
+if [[ -z "$TRACKING_FILE" ]]; then
+  echo "No tracking file configured, nothing to clean up."
+  write_summary "### Cluster Cleanup"$'\n'"No tracking file configured. Nothing to clean up."
+  exit 0
+fi
+
+if [[ ! -f "$TRACKING_FILE" ]]; then
+  echo "Tracking file not found, nothing to clean up."
+  write_summary "### Cluster Cleanup"$'\n'"Tracking file not found. Nothing to clean up."
+  exit 0
+fi
+
+target_ids=()
+while IFS=' ' read -r id _; do
+  if [[ -n "$id" ]]; then
+    target_ids+=("$id")
+  fi
+done < "$TRACKING_FILE"
+
+if [[ ${#target_ids[@]} -eq 0 ]]; then
+  echo "Tracking file is empty, nothing to clean up."
+  write_summary "### Cluster Cleanup"$'\n'"Tracking file is empty. No orphaned clusters."
+  exit 0
+fi
+
+log_notice "Found ${#target_ids[@]} tracked cluster(s) to check" "Cluster Cleanup"
+echo ""
+
+# Fetch details for each tracked cluster.
+log_group "Fetching cluster details"
+printf "%-40s %-38s %-12s %s\n" "NAME" "ID" "STATE" "CREATED_AT"
+printf "%-40s %-38s %-12s %s\n" "----" "--" "-----" "----------"
+
+clusters_to_delete=()
+summary_rows=()
+
+for id in "${target_ids[@]}"; do
+  cluster_json=$(fetch_cluster "$id" 2>/dev/null || echo "")
+  if [[ -z "$cluster_json" ]]; then
+    log_warning "Could not fetch cluster ${id} (may already be deleted)" "Cluster Not Found"
+    summary_rows+=("| (unknown) | \`${id}\` | — | — | Skipped (not found) |")
+    continue
+  fi
+
+  name=$(echo "$cluster_json" | jq -r '.name')
+  state=$(echo "$cluster_json" | jq -r '.state')
+  created=$(echo "$cluster_json" | jq -r '.created_at')
+
+  printf "%-40s %-38s %-12s %s\n" "$name" "$id" "$state" "$created"
+
+  if [[ "$state" == "DELETED" ]]; then
+    echo "  (already deleted, skipping)"
+    summary_rows+=("| \`${name}\` | \`${id}\` | ${state} | ${created} | Already deleted |")
+    continue
+  fi
+
+  clusters_to_delete+=("${id}|${name}|${state}|${created}")
+done
+log_endgroup
+
+echo ""
+
+if [[ ${#clusters_to_delete[@]} -eq 0 ]]; then
+  echo "No clusters need deletion."
+  write_summary "### Cluster Cleanup"$'\n'"Checked ${#target_ids[@]} tracked cluster(s). No orphans found."
+  exit 0
+fi
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "[DRY RUN] Would delete ${#clusters_to_delete[@]} cluster(s). Exiting."
+  write_summary "### Cluster Cleanup (Dry Run)"$'\n'"Would delete ${#clusters_to_delete[@]} cluster(s). No action taken."
+  exit 0
+fi
+
+# Delete orphaned clusters.
+log_group "Deleting ${#clusters_to_delete[@]} cluster(s)"
+
+success_count=0
+fail_count=0
+
+for entry in "${clusters_to_delete[@]}"; do
+  id="${entry%%|*}"
+  rest="${entry#*|}"
+  name="${rest%%|*}"
+  rest="${rest#*|}"
+  state="${rest%%|*}"
+  created="${rest#*|}"
+
+  if delete_cluster "$id" "$name"; then
+    success_count=$((success_count + 1))
+    summary_rows+=("| \`${name}\` | \`${id}\` | ${state} | ${created} | Deleted |")
+  else
+    fail_count=$((fail_count + 1))
+    summary_rows+=("| \`${name}\` | \`${id}\` | ${state} | ${created} | **Failed** |")
+  fi
+done
+log_endgroup
+
+echo ""
+echo "=== Summary ==="
+echo "Deleted: ${success_count}"
+echo "Failed:  ${fail_count}"
+
+# Write step summary.
+{
+  write_summary "### Cluster Cleanup"
+  write_summary ""
+  write_summary "| Name | ID | State | Created | Outcome |"
+  write_summary "|------|-----|-------|---------|---------|"
+  for row in "${summary_rows[@]}"; do
+    write_summary "$row"
+  done
+  write_summary ""
+  write_summary "**Deleted:** ${success_count} | **Failed:** ${fail_count}"
+}
+
+if [[ "$fail_count" -gt 0 ]]; then
+  log_error "Failed to delete ${fail_count} cluster(s)" "Cluster Cleanup"
+  exit 1
+fi


### PR DESCRIPTION
This PR creates a GitHub Actions script to clean up real clusters created during acceptance test runs, on both successful and failed runs. The post-run cleanup script is idempotent: clusters already cleaned up as part of a successful acceptance test run result in a no-op.

When acceptance tests time out (Go's -timeout 120m kills all goroutines without running defer blocks), clusters created during the test run are left orphaned in the testing org. This adds automatic cleanup that runs after every acceptance test workflow, whether tests pass, fail, or time out.

The provider now tracks cluster IDs in a file during test runs via `CLEANUP_TRACKING_FILE`. The tracking wrapper is only constructed in provider.Configure when this env var is set, so customer runs of the provider are unaffected. A post-test cleanup step (if: always()) reads the tracking file and deletes any clusters that were created but not destroyed. Each workflow run uses its own tracking file, so concurrent runs only clean up their own clusters.

**Commit checklist**
- [ ] Changelog (N/a internal CI change)
- [ ] Doc gen (`make generate`) (N/a no schema changes)
- [x] Integration test(s)
- [x] Acceptance test(s) [Link](https://github.com/cockroachdb/terraform-provider-cockroach/actions/runs/25071942710) shows the logs with the new script working.
- [ ] Example(s) (N/a no new resources)
