### PR TITLE
ci: declare workflow-level `contents: read` on ci and build workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: read
+
 jobs:
 
   # Post job to build terraform-provider on merge to master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,9 @@ on:
       - 'main'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   # pre job run golangci-lint


### PR DESCRIPTION
Both workflows run pure Go build/test (`ci.yaml` runs lint + tests, `build.yaml` does the Go build). No GitHub API writes from either workflow.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.