### PR TITLE
fix with_empty_ip_allowlist losing state on plan updates

### DIFF
--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -265,6 +265,7 @@ func (r *clusterResource) Schema(
 					},
 					"with_empty_ip_allowlist": schema.BoolAttribute{
 						Optional: true,
+						Computed: true,
 						PlanModifiers: []planmodifier.Bool{
 							boolplanmodifier.UseStateForUnknown(),
 						},
@@ -1534,7 +1535,10 @@ func loadClusterToTerraformState(
 			}
 		}
 
-		if plan != nil && plan.ServerlessConfig != nil {
+		// The API doesn't return with_empty_ip_allowlist, so we preserve it from the plan.
+		// Guard with IsKnown: on initial create without the attribute, the Computed+UseStateForUnknown
+		// combo produces an unknown plan value that must not leak into state.
+		if plan != nil && plan.ServerlessConfig != nil && IsKnown(plan.ServerlessConfig.WithEmptyIpAllowlist) {
 			serverlessConfig.WithEmptyIpAllowlist = plan.ServerlessConfig.WithEmptyIpAllowlist
 		}
 


### PR DESCRIPTION
Without Computed: true, UseStateForUnknown never fires because Terraform plans an omitted Optional-only attribute as null (not unknown). This caused the [acceptance test to fail](https://github.com/cockroachdb/terraform-provider-cockroach/actions/runs/26471447488/job/77945707870) at step 2 when the attribute was removed from config but expected to persist.

Guard the state copy with IsKnown so that on initial create (where there is no prior state and the plan value is unknown) the value resolves to null instead of leaking an unknown into state.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
