### PR TITLE
[CC-36163]: add enable_sending_queue option to log export configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `enable_sending_queue` option to the `groups` block on `cockroach_log_export_config`. When enabled, logs in the group are buffered to a persistent disk-backed queue, allowing them to survive pod restarts and temporary sink outages. Only one group per cluster can have this option enabled.
 - Added `with_empty_ip_allowlist` option to the `serverless` block on `cockroach_cluster`. Set to `true` to create a serverless cluster with no default IP allowlist entries, requiring explicit allowlist configuration. This is a create-only field and cannot be changed after cluster creation.
 
 ## [1.20.0] - 2026-04-22

--- a/docs/resources/log_export_config.md
+++ b/docs/resources/log_export_config.md
@@ -36,7 +36,8 @@ resource "cockroach_log_export_config" "example" {
     {
       log_name : "sql",
       channels : ["SQL_SCHEMA", "SQL_EXEC"],
-      redact : false
+      redact : false,
+      enable_sending_queue : true
     },
     {
       log_name : "devops",
@@ -86,6 +87,7 @@ Required:
 
 Optional:
 
+- `enable_sending_queue` (Boolean) Enables the sending queue for logs in this group. Only one group can have enable_sending_queue enabled.
 - `min_level` (String) The minimum log level to filter to this log group.
 - `redact` (Boolean) Governs whether this log group should aggregate redacted logs if unset.
 

--- a/examples/resources/cockroach_log_export_config/resource.tf
+++ b/examples/resources/cockroach_log_export_config/resource.tf
@@ -21,7 +21,8 @@ resource "cockroach_log_export_config" "example" {
     {
       log_name : "sql",
       channels : ["SQL_SCHEMA", "SQL_EXEC"],
-      redact : false
+      redact : false,
+      enable_sending_queue : true
     },
     {
       log_name : "devops",

--- a/internal/provider/log_export_config_resource.go
+++ b/internal/provider/log_export_config_resource.go
@@ -83,6 +83,10 @@ var logExportAttributes = map[string]schema.Attribute{
 					Optional:            true,
 					MarkdownDescription: "Governs whether this log group should aggregate redacted logs if unset.",
 				},
+				"enable_sending_queue": schema.BoolAttribute{
+					Optional:            true,
+					MarkdownDescription: "Enables the sending queue for logs in this group. Only one group can have enable_sending_queue enabled.",
+				},
 			},
 		},
 	},
@@ -311,11 +315,18 @@ func loadLogExportIntoTerraformState(
 			} else {
 				groupMinLevel = types.StringValue(string(apiGroup.GetMinLevel()))
 			}
+			var groupEnableSendingQueue types.Bool
+			if apiGroup.EnableSendingQueue == nil {
+				groupEnableSendingQueue = types.BoolNull()
+			} else {
+				groupEnableSendingQueue = types.BoolValue(apiGroup.GetEnableSendingQueue())
+			}
 			groups[group_idx] = LogExportGroup{
-				LogName:  types.StringValue(apiGroup.GetLogName()),
-				Channels: channels,
-				MinLevel: groupMinLevel,
-				Redact:   groupRedact,
+				LogName:            types.StringValue(apiGroup.GetLogName()),
+				Channels:           channels,
+				MinLevel:           groupMinLevel,
+				Redact:             groupRedact,
+				EnableSendingQueue: groupEnableSendingQueue,
 			}
 		}
 	}
@@ -495,6 +506,10 @@ func logExportGroupToClientGroup(group LogExportGroup) (*client.LogExportGroup, 
 
 	if IsKnown(group.Redact) {
 		clientGroup.SetRedact(group.Redact.ValueBool())
+	}
+
+	if IsKnown(group.EnableSendingQueue) {
+		clientGroup.SetEnableSendingQueue(group.EnableSendingQueue.ValueBool())
 	}
 
 	if !IsKnown(group.MinLevel) {

--- a/internal/provider/log_export_config_resource_test.go
+++ b/internal/provider/log_export_config_resource_test.go
@@ -89,7 +89,7 @@ func TestIntegrationLogExportConfigResource(t *testing.T) {
 	trueBool := true
 	minLevel, _ := client.NewLogLevelTypeFromValue("WARNING")
 	createdGroups := []client.LogExportGroup{
-		{LogName: "sql", Channels: []string{"SQL_SCHEMA", "SQL_EXEC"}, MinLevel: minLevel, Redact: &trueBool},
+		{LogName: "sql", Channels: []string{"SQL_SCHEMA", "SQL_EXEC"}, MinLevel: minLevel, Redact: &trueBool, EnableSendingQueue: &trueBool},
 	}
 	omittedChannels := []string{"SQL_PERF"}
 	enabledStatus, _ := client.NewLogExportStatusFromValue("ENABLED")
@@ -109,8 +109,8 @@ func TestIntegrationLogExportConfigResource(t *testing.T) {
 
 	falseBool := false
 	updatedGroups := []client.LogExportGroup{
-		{LogName: "sql", Channels: []string{"SQL_EXEC"}, MinLevel: minLevel, Redact: &trueBool},
-		{LogName: "devops", Channels: []string{"OPS", "HEALTH", "STORAGE"}, MinLevel: minLevel, Redact: &falseBool},
+		{LogName: "sql", Channels: []string{"SQL_EXEC"}, MinLevel: minLevel, Redact: &trueBool, EnableSendingQueue: &falseBool},
+		{LogName: "devops", Channels: []string{"OPS", "HEALTH", "STORAGE"}, MinLevel: minLevel, Redact: &falseBool, EnableSendingQueue: &trueBool},
 	}
 	updatedOChannels := []string{"SQL_SCHEMA"}
 	updatedExternalID := "test-external-id"
@@ -204,6 +204,7 @@ func testLogExportConfigResource(t *testing.T, clusterName string, useMock bool)
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "redact", "true"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.#", "1"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.0.channels.#", "2"),
+					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.0.enable_sending_queue", "true"),
 					resource.TestCheckNoResourceAttr(logExportConfigResourceName, "aws_external_id"),
 				),
 			},
@@ -214,6 +215,8 @@ func testLogExportConfigResource(t *testing.T, clusterName string, useMock bool)
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "redact", "false"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.#", "2"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.0.channels.#", "1"),
+					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.0.enable_sending_queue", "false"),
+					resource.TestCheckResourceAttr(logExportConfigResourceName, "groups.1.enable_sending_queue", "true"),
 					resource.TestCheckResourceAttr(logExportConfigResourceName, "aws_external_id", "test-external-id"),
 				),
 			},
@@ -279,10 +282,11 @@ resource "cockroach_log_export_config" "test" {
   region         = "us-east-1"
   groups = [
     {
-      log_name  = "sql",
-      channels  = ["SQL_SCHEMA", "SQL_EXEC"],
-      min_level = "WARNING",
-      redact    = true
+      log_name             = "sql",
+      channels             = ["SQL_SCHEMA", "SQL_EXEC"],
+      min_level            = "WARNING",
+      redact               = true,
+      enable_sending_queue = true
     }
   ]
   omitted_channels = ["SQL_PERF"]
@@ -315,16 +319,18 @@ resource "cockroach_log_export_config" "test" {
   aws_external_id = "test-external-id"
   groups = [
     {
-      log_name  = "sql",
-      channels  = ["SQL_EXEC"],
-      min_level = "WARNING",
-      redact : true
+      log_name             = "sql",
+      channels             = ["SQL_EXEC"],
+      min_level            = "WARNING",
+      redact               = true,
+      enable_sending_queue = false
     },
     {
-      log_name  = "devops",
-      channels  = ["OPS", "HEALTH", "STORAGE"],
-      min_level = "WARNING",
-      redact    = false
+      log_name             = "devops",
+      channels             = ["OPS", "HEALTH", "STORAGE"],
+      min_level            = "WARNING",
+      redact               = false,
+      enable_sending_queue = true
     }
   ]
   omitted_channels = ["SQL_SCHEMA"]

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -261,10 +261,11 @@ type PersonUser struct {
 }
 
 type LogExportGroup struct {
-	LogName  types.String   `tfsdk:"log_name"`
-	Channels []types.String `tfsdk:"channels"`
-	MinLevel types.String   `tfsdk:"min_level"`
-	Redact   types.Bool     `tfsdk:"redact"`
+	LogName            types.String   `tfsdk:"log_name"`
+	Channels           []types.String `tfsdk:"channels"`
+	MinLevel           types.String   `tfsdk:"min_level"`
+	Redact             types.Bool     `tfsdk:"redact"`
+	EnableSendingQueue types.Bool     `tfsdk:"enable_sending_queue"`
 }
 
 type ClusterLogExport struct {


### PR DESCRIPTION
This adds the `enable_sending_queue` boolean field to the `groups` block on the `cockroach_log_export_config` resource. When enabled on a log export group, logs are buffered to a persistent disk-backed sending queue in the OTel collector. This allows exported logs to survive pod restarts and temporary sink outages.

The API enforces that only one group per cluster can have `enable_sending_queue` set to true; server-side validation rejects configurations with multiple groups enabled.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
