### PR TITLE
fix with_empty_ip_allowlist allowing true→false change after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `with_empty_ip_allowlist` validation allowing the attribute to be changed from `true` to `false` after cluster creation.
+
 ## [1.21.1] - 2026-05-29
 
 ### Fixed

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -976,11 +976,10 @@ func (r *clusterResource) ModifyPlan(
 		}
 		if serverless := plan.ServerlessConfig; serverless != nil &&
 			state.ServerlessConfig != nil &&
-			serverless.WithEmptyIpAllowlist.ValueBool() &&
-			!state.ServerlessConfig.WithEmptyIpAllowlist.ValueBool() {
+			serverless.WithEmptyIpAllowlist.ValueBool() != state.ServerlessConfig.WithEmptyIpAllowlist.ValueBool() {
 			resp.Diagnostics.AddError(
 				"Cannot update with_empty_ip_allowlist",
-				"The with_empty_ip_allowlist field can only be set during cluster creation. It cannot be enabled on an existing cluster.")
+				"The with_empty_ip_allowlist field can only be set during cluster creation. It cannot be changed after cluster creation.")
 		}
 	}
 

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -1424,6 +1424,58 @@ func TestIntegrationServerlessClusterResource(t *testing.T) {
 				return step
 			},
 		},
+		{
+			name: "attempt to change with_empty_ip_allowlist from true to false",
+			createStep: func() resource.TestStep {
+				return serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					withEmptyIpAllowlist: ptr(true),
+				})
+			},
+			initialCluster: singleRegionClusterWithUnlimited("BASIC"),
+			updateStep: func() resource.TestStep {
+				step := serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					withEmptyIpAllowlist: ptr(false),
+				})
+				step.ExpectError = regexp.MustCompile("Cannot update with_empty_ip_allowlist")
+				return step
+			},
+		},
+		{
+			name: "attempt to change with_empty_ip_allowlist from false to true",
+			createStep: func() resource.TestStep {
+				return serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					withEmptyIpAllowlist: ptr(false),
+				})
+			},
+			initialCluster: singleRegionClusterWithUnlimited("BASIC"),
+			updateStep: func() resource.TestStep {
+				step := serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					withEmptyIpAllowlist: ptr(true),
+				})
+				step.ExpectError = regexp.MustCompile("Cannot update with_empty_ip_allowlist")
+				return step
+			},
+		},
+		{
+			// Include a usage limit change so that an update is triggered;
+			// removing with_empty_ip_allowlist alone produces no diff because
+			// UseStateForUnknown preserves the state value.
+			name: "remove with_empty_ip_allowlist after creation",
+			createStep: func() resource.TestStep {
+				return serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					withEmptyIpAllowlist: ptr(true),
+				})
+			},
+			initialCluster: singleRegionClusterWithUnlimited("BASIC"),
+			updateStep: func() resource.TestStep {
+				return serverlessClusterStep(clusterName, "BASIC", slsConfig{
+					requestUnitLimit: ptr(int64(1_000_000)),
+					storageMibLimit:  ptr(int64(1024)),
+				})
+			},
+			finalCluster:      singleRegionClusterWithLimits("BASIC", 1_000_000, 1024),
+			ignoreImportPaths: []string{"serverless.with_empty_ip_allowlist"},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
The validation only checked for false→true, so explicitly setting the attribute to false after creation was silently accepted.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
