### PR TITLE
provider: allow setting per-region vCPU/machine type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `num_virtual_cpus` and `machine_type` attributes to the `regions` block on
+  `cockroach_cluster`, enabling heterogeneous Advanced clusters whose regions use
+  different machine types. These are mutually exclusive with the cluster-wide
+  `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with each other within a
+  region, and must be set on every region when used. Requires a feature flag to be
+  enabled on your organization.
+
 ### Changed
 
 - Bumped version of cockroach-cloud-sdk-go from v7 to v8.

--- a/docs/data-sources/cluster.md
+++ b/docs/data-sources/cluster.md
@@ -116,8 +116,10 @@ Read-Only:
 Read-Only:
 
 - `internal_dns` (String) Internal DNS name of the cluster within the cloud provider's network. Used to connect to the cluster with PrivateLink or VPC peering.
+- `machine_type` (String) Machine type identifier per node in this region, e.g., m6.xlarge, n2-standard-4. May differ across regions in a heterogeneous Advanced cluster. Only populated for Advanced clusters.
 - `name` (String) Region code used by the cluster's cloud provider.
 - `node_count` (Number) Number of nodes in the region. Will always be 0 for serverless clusters.
+- `num_virtual_cpus` (Number) Number of virtual CPUs per node in this region. May differ across regions in a heterogeneous Advanced cluster. Only populated for Advanced clusters.
 - `primary` (Boolean) Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.
 - `private_endpoint_dns` (String) Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.
 - `s3_vpc_endpoint_id` (String) The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.

--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -39,6 +39,36 @@ resource "cockroach_cluster" "advanced" {
   }
 }
 
+# A heterogeneous Advanced cluster: each region uses a different machine size.
+# Per-region num_virtual_cpus/machine_type are mutually exclusive with the
+# cluster-wide dedicated.num_virtual_cpus/machine_type, and must be set on every
+# region. This requires a feature flag to be enabled on your organization.
+resource "cockroach_cluster" "advanced_heterogeneous" {
+  name           = "cockroach-advanced-heterogeneous"
+  cloud_provider = "GCP"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    {
+      name             = "us-central1"
+      node_count       = 3
+      num_virtual_cpus = 4
+    },
+    {
+      name             = "us-east1"
+      node_count       = 3
+      num_virtual_cpus = 8
+    },
+    {
+      name             = "us-west1"
+      node_count       = 3
+      num_virtual_cpus = 8
+    }
+  ]
+}
+
 resource "cockroach_cluster" "standard" {
   name           = "cockroach-standard"
   cloud_provider = "GCP"
@@ -152,7 +182,9 @@ Required:
 
 Optional:
 
+- `machine_type` (String) Machine type identifier per node in this region, e.g., m6.xlarge, n2-standard-4. Set this (or `num_virtual_cpus`) on every region to create a heterogeneous Advanced cluster. Mutually exclusive with the cluster-wide `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with `num_virtual_cpus` on the same region. This attribute requires a feature flag to be enabled; it is recommended to use `num_virtual_cpus` instead. Valid for Advanced clusters only.
 - `node_count` (Number) Number of nodes in the region. Valid for Advanced clusters only.
+- `num_virtual_cpus` (Number) Number of virtual CPUs per node in this region. Set this (or `machine_type`) on every region to create a heterogeneous Advanced cluster whose regions use different machine types. Mutually exclusive with the cluster-wide `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with `machine_type` on the same region. Requires a feature flag to be enabled; valid for Advanced clusters only.
 - `primary` (Boolean) Set to true to mark this region as the primary for a serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.
 
 Read-Only:
@@ -217,7 +249,7 @@ Optional:
 - `cidr_range` (String) The IPv4 range in CIDR format that will be used by the cluster. This is supported only on GCP, and must have a subnet mask no larger than /19. Defaults to "172.28.0.0/14". This cannot be changed after cluster creation.
 - `disk_iops` (Number) Number of disk I/O operations per second that are permitted on each node in the cluster. Only configurable for AWS clusters during creation. For GCP and Azure clusters, this value is ignored and the cloud provider default is used. Omit this attribute to use the server-side default based on machine type and storage size. The provisioned value may differ from the requested value.
 - `machine_type` (String) Machine type identifier within the given cloud provider, e.g., m6.xlarge, n2-standard-4. This attribute requires a feature flag to be enabled. It is recommended to leave this empty and use `num_virtual_cpus` to control the machine type.
-- `num_virtual_cpus` (Number) Number of virtual CPUs per node in the cluster.
+- `num_virtual_cpus` (Number) Number of virtual CPUs per node in the cluster. Mutually exclusive with per-region `regions[].num_virtual_cpus`/`machine_type`.
 - `private_network_visibility` (Boolean) Set to true to assign private IP addresses to nodes. Required for CMEK and other advanced networking features. Clusters created with this flag will have advanced security features enabled.  This cannot be changed after cluster creation and incurs additional charges.  See [Create an Advanced Cluster](https://www.cockroachlabs.com/docs/cockroachcloud/create-an-advanced-cluster.html#step-6-configure-advanced-security-features) and [Pricing](https://www.cockroachlabs.com/pricing/) for more information.
 - `storage_gib` (Number) Storage amount per node in GiB.
 - `supports_cluster_virtualization` (Boolean) supports_cluster_virtualization specifies whether an Advanced cluster is started with a virtual cluster architecture. This field is restricted to Private Preview usage; see our documentation for details: https://www.cockroachlabs.com/docs/stable/cluster-virtualization-overview

--- a/examples/resources/cockroach_cluster/resource.tf
+++ b/examples/resources/cockroach_cluster/resource.tf
@@ -24,6 +24,36 @@ resource "cockroach_cluster" "advanced" {
   }
 }
 
+# A heterogeneous Advanced cluster: each region uses a different machine size.
+# Per-region num_virtual_cpus/machine_type are mutually exclusive with the
+# cluster-wide dedicated.num_virtual_cpus/machine_type, and must be set on every
+# region. This requires a feature flag to be enabled on your organization.
+resource "cockroach_cluster" "advanced_heterogeneous" {
+  name           = "cockroach-advanced-heterogeneous"
+  cloud_provider = "GCP"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    {
+      name             = "us-central1"
+      node_count       = 3
+      num_virtual_cpus = 4
+    },
+    {
+      name             = "us-east1"
+      node_count       = 3
+      num_virtual_cpus = 8
+    },
+    {
+      name             = "us-west1"
+      node_count       = 3
+      num_virtual_cpus = 8
+    }
+  ]
+}
+
 resource "cockroach_cluster" "standard" {
   name           = "cockroach-standard"
   cloud_provider = "GCP"

--- a/internal/provider/cluster_data_source.go
+++ b/internal/provider/cluster_data_source.go
@@ -209,6 +209,14 @@ func (d *clusterDataSource) Schema(
 							Computed:    true,
 							Description: "Number of nodes in the region. Will always be 0 for serverless clusters.",
 						},
+						"num_virtual_cpus": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Number of virtual CPUs per node in this region. May differ across regions in a heterogeneous Advanced cluster. Only populated for Advanced clusters.",
+						},
+						"machine_type": schema.StringAttribute{
+							Computed:    true,
+							Description: "Machine type identifier per node in this region, e.g., m6.xlarge, n2-standard-4. May differ across regions in a heterogeneous Advanced cluster. Only populated for Advanced clusters.",
+						},
 						"primary": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Denotes whether this is the primary region in a serverless cluster. Dedicated clusters don't have a primary region.",
@@ -350,7 +358,9 @@ func (d *clusterDataSource) Read(
 	// The concept of a plan doesn't apply to data sources.
 	// Using a nil plan means we won't try to re-sort the region list.
 	var newState CockroachCluster
-	loadClusterToTerraformState(ctx, cockroachCluster, remoteBackupConfig, &newState, nil)
+	resp.Diagnostics.Append(
+		loadClusterToTerraformState(ctx, cockroachCluster, remoteBackupConfig, &newState, nil)...,
+	)
 	diags = resp.State.Set(ctx, newState)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -108,6 +108,22 @@ var regionSchema = schema.NestedAttributeObject{
 			},
 			Description: "Number of nodes in the region. Valid for Advanced clusters only.",
 		},
+		"num_virtual_cpus": schema.Int64Attribute{
+			Optional: true,
+			Computed: true,
+			PlanModifiers: []planmodifier.Int64{
+				int64planmodifier.UseStateForUnknown(),
+			},
+			MarkdownDescription: "Number of virtual CPUs per node in this region. Set this (or `machine_type`) on every region to create a heterogeneous Advanced cluster whose regions use different machine types. Mutually exclusive with the cluster-wide `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with `machine_type` on the same region. Requires a feature flag to be enabled; valid for Advanced clusters only.",
+		},
+		"machine_type": schema.StringAttribute{
+			Optional: true,
+			Computed: true,
+			PlanModifiers: []planmodifier.String{
+				SuppressMachineTypeDrift(),
+			},
+			MarkdownDescription: "Machine type identifier per node in this region, e.g., m6.xlarge, n2-standard-4. Set this (or `num_virtual_cpus`) on every region to create a heterogeneous Advanced cluster. Mutually exclusive with the cluster-wide `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with `num_virtual_cpus` on the same region. This attribute requires a feature flag to be enabled; it is recommended to use `num_virtual_cpus` instead. Valid for Advanced clusters only.",
+		},
 		"primary": schema.BoolAttribute{
 			Optional:    true,
 			Computed:    true,
@@ -311,9 +327,12 @@ func (r *clusterResource) Schema(
 						},
 					},
 					"num_virtual_cpus": schema.Int64Attribute{
-						Optional:    true,
-						Computed:    true,
-						Description: "Number of virtual CPUs per node in the cluster.",
+						Optional: true,
+						Computed: true,
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
+						Description: "Number of virtual CPUs per node in the cluster. Mutually exclusive with per-region `regions[].num_virtual_cpus`/`machine_type`.",
 					},
 					"private_network_visibility": schema.BoolAttribute{
 						Optional:            true,
@@ -519,7 +538,39 @@ func (r *clusterResource) ValidateConfig(
 			if IsKnown(region.NodeCount) {
 				resp.Diagnostics.AddAttributeError(path.Root("regions").AtListIndex(i), "Invalid Attribute", "node_count is supported for ADVANCED clusters only.")
 			}
+			if IsKnown(region.NumVirtualCpus) || IsKnown(region.MachineType) {
+				resp.Diagnostics.AddAttributeError(path.Root("regions").AtListIndex(i), "Invalid Attribute", "Per-region num_virtual_cpus and machine_type are supported for ADVANCED clusters only.")
+			}
 		}
+		return
+	}
+
+	// The cluster-wide dedicated.num_virtual_cpus/machine_type and
+	// the per-region regions[].num_virtual_cpus/machine_type are
+	// mutually exclusive.
+	clusterHasMachineType := cluster.DedicatedConfig != nil &&
+		(!cluster.DedicatedConfig.NumVirtualCpus.IsNull() || !cluster.DedicatedConfig.MachineType.IsNull())
+
+	anyRegionHasMachineType := false
+	allRegionsHaveMachineType := true
+	for i, region := range cluster.Regions {
+		if !region.NumVirtualCpus.IsNull() && !region.MachineType.IsNull() {
+			resp.Diagnostics.AddAttributeError(path.Root("regions").AtListIndex(i), "Invalid Attribute Combination",
+				"num_virtual_cpus and machine_type are mutually exclusive within a region.")
+		}
+
+		curHasMachineType := hasRegionMachineType(region)
+		anyRegionHasMachineType = anyRegionHasMachineType || curHasMachineType
+		allRegionsHaveMachineType = allRegionsHaveMachineType && curHasMachineType
+	}
+
+	if anyRegionHasMachineType && clusterHasMachineType {
+		resp.Diagnostics.AddError("Invalid Attribute Combination",
+			"Specify machine types either cluster-wide via dedicated.num_virtual_cpus/machine_type or per-region via regions[].num_virtual_cpus/machine_type, not both.")
+	}
+	if anyRegionHasMachineType && !allRegionsHaveMachineType {
+		resp.Diagnostics.AddError("Invalid Attribute Combination",
+			"When any region specifies num_virtual_cpus or machine_type, every region must specify one.")
 	}
 }
 
@@ -555,6 +606,12 @@ func (r *clusterResource) Create(
 	var plan CockroachCluster
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var config CockroachCluster
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -642,34 +699,31 @@ func (r *clusterResource) Create(
 			}
 			dedicated.RegionNodes = regionNodes
 		}
-		if cfg := plan.DedicatedConfig; cfg != nil {
-			hardware := client.DedicatedHardwareCreateSpecification{}
-			machineSpec := client.DedicatedMachineTypeSpecification{}
-			if IsKnown(cfg.NumVirtualCpus) {
-				cpus := int32(cfg.NumVirtualCpus.ValueInt64())
-				machineSpec.NumVirtualCpus = &cpus
-			} else if IsKnown(cfg.MachineType) {
-				machineType := cfg.MachineType.ValueString()
-				machineSpec.MachineType = &machineType
-			}
+		hardware := client.DedicatedHardwareCreateSpecification{}
+		if regionSpecs, ok := buildRegionMachineSpecs(config.Regions); ok {
+			dedicated.RegionMachineSpecs = &regionSpecs
+		} else {
+			machineSpec := buildClusterWideMachineSpec(config.DedicatedConfig, plan.DedicatedConfig)
 			hardware.MachineSpec = &machineSpec
-			if IsKnown(cfg.StorageGib) {
-				hardware.StorageGib = int32(cfg.StorageGib.ValueInt64())
-			}
-			if IsKnown(cfg.DiskIops) {
-				diskiops := int32(cfg.DiskIops.ValueInt64())
-				hardware.DiskIops = &diskiops
-			}
-			dedicated.Hardware = hardware
-			if cfg.PrivateNetworkVisibility.ValueBool() {
-				visibilityPrivate := client.NETWORKVISIBILITYTYPE_PRIVATE
-				dedicated.NetworkVisibility = &visibilityPrivate
-			}
-			if cfg.CidrRange.ValueString() != "" {
-				dedicated.CidrRange = ptr(cfg.CidrRange.ValueString())
-			}
-			dedicated.SupportsClusterVirtualization = ptr(cfg.SupportsClusterVirtualization.ValueBool())
 		}
+
+		cfg := plan.DedicatedConfig
+		if IsKnown(cfg.StorageGib) {
+			hardware.StorageGib = int32(cfg.StorageGib.ValueInt64())
+		}
+		if IsKnown(cfg.DiskIops) {
+			diskiops := int32(cfg.DiskIops.ValueInt64())
+			hardware.DiskIops = &diskiops
+		}
+		dedicated.Hardware = hardware
+		if cfg.PrivateNetworkVisibility.ValueBool() {
+			visibilityPrivate := client.NETWORKVISIBILITYTYPE_PRIVATE
+			dedicated.NetworkVisibility = &visibilityPrivate
+		}
+		if cfg.CidrRange.ValueString() != "" {
+			dedicated.CidrRange = ptr(cfg.CidrRange.ValueString())
+		}
+		dedicated.SupportsClusterVirtualization = ptr(cfg.SupportsClusterVirtualization.ValueBool())
 		clusterSpec.SetDedicated(dedicated)
 	}
 
@@ -931,6 +985,13 @@ func (r *clusterResource) ModifyPlan(
 		return
 	}
 
+	var config *CockroachCluster
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan != nil {
 		if plan.Name != state.Name {
 			resp.Diagnostics.AddError("Cannot update cluster name",
@@ -981,6 +1042,12 @@ func (r *clusterResource) ModifyPlan(
 			resp.Diagnostics.AddError(
 				"Cannot update with_empty_ip_allowlist",
 				"The with_empty_ip_allowlist field can only be set during cluster creation. It cannot be enabled on an existing cluster.")
+		}
+
+		// Coordinate the dedicated machine plan so per-field plan modifiers don't
+		// leave stale-but-known values that a resize/add/remove would invalidate.
+		if coordinateDedicatedMachinePlan(config, plan, state) {
+			resp.Diagnostics.Append(resp.Plan.Set(ctx, plan)...)
 		}
 	}
 
@@ -1041,6 +1108,13 @@ func (r *clusterResource) Update(
 	var state CockroachCluster
 	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Machine-type mode is decided from config, not plan; see buildRegionMachineSpecs.
+	var config CockroachCluster
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -1191,15 +1265,13 @@ func (r *clusterResource) Update(
 			diskiops := int32(plan.DedicatedConfig.DiskIops.ValueInt64())
 			dedicated.Hardware.DiskIops = &diskiops
 		}
-		machineSpec := client.DedicatedMachineTypeSpecification{}
-		if IsKnown(plan.DedicatedConfig.MachineType) {
-			machineType := plan.DedicatedConfig.MachineType.ValueString()
-			machineSpec.MachineType = &machineType
-		} else if IsKnown(plan.DedicatedConfig.NumVirtualCpus) {
-			cpus := int32(plan.DedicatedConfig.NumVirtualCpus.ValueInt64())
-			machineSpec.NumVirtualCpus = &cpus
+
+		if regionSpecs, ok := buildRegionMachineSpecs(config.Regions); ok {
+			dedicated.RegionMachineSpecs = &regionSpecs
+		} else {
+			machineSpec := buildClusterWideMachineSpec(config.DedicatedConfig, plan.DedicatedConfig)
+			dedicated.Hardware.MachineSpec = &machineSpec
 		}
-		dedicated.Hardware.MachineSpec = &machineSpec
 
 		clusterReq.SetDedicated(*dedicated)
 	}
@@ -1485,11 +1557,12 @@ func loadClusterToTerraformState(
 	} else {
 		state.CustomerCloudAccount = nil
 	}
+	var allDiags diag.Diagnostics
 	var planRegions []Region
 	if plan != nil {
 		planRegions = plan.Regions
 	}
-	state.Regions = getManagedRegions(&clusterObj.Regions, planRegions)
+	state.Regions = getManagedRegions(&clusterObj.Regions, planRegions, clusterObj.CloudProvider, &allDiags)
 	state.UpgradeStatus = types.StringValue(string(clusterObj.UpgradeStatus))
 
 	if clusterObj.ParentId == nil {
@@ -1498,7 +1571,6 @@ func loadClusterToTerraformState(
 		state.ParentId = types.StringValue(*clusterObj.ParentId)
 	}
 
-	var allDiags diag.Diagnostics
 	labels, diags := types.MapValueFrom(ctx, types.StringType, clusterObj.Labels)
 	state.Labels = labels
 	allDiags.Append(diags...)
@@ -1567,29 +1639,17 @@ func loadClusterToTerraformState(
 			// machine_type that differs from the API response but has
 			// the same vCPU count (e.g., m6i→m7g), preserve
 			// the previous value. A warning is emitted so users know
-			// the server converted the type.
+			// the server converted the type. If either machine type
+			// couldn't be parsed, the API value remains in state so
+			// unrecognized formats surface as normal Terraform drift.
 			if IsKnown(plan.DedicatedConfig.MachineType) {
-				planMT := plan.DedicatedConfig.MachineType.ValueString()
-				apiMT := clusterObj.Config.Dedicated.MachineType
-				if planMT != apiMT {
-					planVCPUs, planOk := extractVCPUCount(clusterObj.CloudProvider, planMT)
-					apiVCPUs, apiOk := extractVCPUCount(clusterObj.CloudProvider, apiMT)
-					if planOk && apiOk && planVCPUs == apiVCPUs {
-						state.DedicatedConfig.MachineType = plan.DedicatedConfig.MachineType
-						allDiags.AddWarning(
-							"Machine type converted by server",
-							fmt.Sprintf(
-								"The server is running machine_type %q instead of %q "+
-									"(same vCPU count: %d). Update your configuration "+
-									"to use %q to remove this warning.",
-								apiMT, planMT, planVCPUs, apiMT,
-							),
-						)
-					}
-					// If either machine type couldn't be parsed, fall through
-					// and let the API value remain in state. This ensures
-					// unrecognized formats surface as normal Terraform drift.
-				}
+				state.DedicatedConfig.MachineType = suppressMachineTypeDrift(
+					plan.DedicatedConfig.MachineType,
+					clusterObj.Config.Dedicated.MachineType,
+					"", // cluster-wide
+					clusterObj.CloudProvider,
+					&allDiags,
+				)
 			}
 		}
 	}
@@ -1656,36 +1716,328 @@ func providerBackupConfigToClientBackupConfig(
 	return backupUpdateRequest, diags
 }
 
-// Due to the cyclic dependency issues of CMEK, there may be additional
-// regions that are managed by another resource (i.e. cockroach_cmek) that
-// we can safely omit from the state.
-func getManagedRegions(apiRegions *[]client.Region, plan []Region) []Region {
+// hasRegionMachineType reports whether a region specifies a per-region
+// machine type.
+func hasRegionMachineType(r Region) bool {
+	return !r.NumVirtualCpus.IsNull() || !r.MachineType.IsNull()
+}
+
+// isHeterogeneous reports whether any region specifies a per-region machine type.
+func isHeterogeneous(regions []Region) bool {
+	for _, r := range regions {
+		if hasRegionMachineType(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveMachinePlan computes the planned (num_virtual_cpus, machine_type) for a
+// homogeneous cluster's dedicated block or a single heterogeneous region.
+//
+// The user-driven field (the one set in config) is authoritative. The computed
+// sibling is taken from the prior state — matched BY NAME by the caller, so it is
+// correct even when the region list is reordered (e.g. a region is removed and the
+// remaining regions shift index, which would otherwise let the field-scoped plan
+// modifiers carry a different region's value forward). The sibling is set unknown
+// (recomputed from the API) when the driver changed vs state or there is no prior
+// state (a new region). It returns changed=true when a value was set unknown, i.e.
+// a resize/recompute is happening.
+func resolveMachinePlan(
+	configVCPUs types.Int64, configMT types.String,
+	stateVCPUs types.Int64, stateMT types.String, hasState bool,
+) (types.Int64, types.String, bool) {
+	switch {
+	case !configVCPUs.IsNull() && configMT.IsNull():
+		// num_virtual_cpus drives, machine_type is computed.
+		if hasState && IsKnown(configVCPUs) && configVCPUs.Equal(stateVCPUs) {
+			return configVCPUs, stateMT, false
+		}
+		return configVCPUs, types.StringUnknown(), true
+	case !configMT.IsNull() && configVCPUs.IsNull():
+		// machine_type drives, num_virtual_cpus is computed.
+		if hasState && IsKnown(configMT) && configMT.Equal(stateMT) {
+			return stateVCPUs, configMT, false
+		}
+		return types.Int64Unknown(), configMT, true
+	default:
+		// Neither set in config (rely on computed values) — keep the prior state.
+		return stateVCPUs, stateMT, false
+	}
+}
+
+// coordinateDedicatedMachinePlan shapes the dedicated machine plan in a single
+// region-diff-aware pass so the field-scoped plan modifiers
+// (SuppressMachineTypeDrift / UseStateForUnknown) don't leave a stale-but-known
+// value that a resize, region addition, or region removal would invalidate at
+// apply time ("inconsistent result after apply"). It decides the mode from CONFIG
+// (the plan can carry modifier-populated values that don't reflect intent) and
+// mutates plan in place, returning whether anything changed.
+//
+// The per-region sibling-coordination rule lives in resolveMachinePlan; this
+// function orchestrates it across all regions plus the cluster-wide block and the
+// derived computed fields. It must be called with a non-nil state (an update).
+func coordinateDedicatedMachinePlan(config, plan, state *CockroachCluster) bool {
+	if config == nil || plan == nil || plan.DedicatedConfig == nil {
+		return false
+	}
+
+	changed := false
+	// resizing tracks whether a machine-spec change is happening (a sibling was
+	// recomputed, or a region was added/removed). When it is, the cluster-wide
+	// derived computed fields must be recomputed too.
+	resizing := false
+	heterogeneous := isHeterogeneous(config.Regions)
+
+	stateByName := make(map[string]Region, len(state.Regions))
+	for _, r := range state.Regions {
+		stateByName[r.Name.ValueString()] = r
+	}
+	configByName := make(map[string]Region, len(config.Regions))
+	for _, r := range config.Regions {
+		configByName[r.Name.ValueString()] = r
+	}
+
+	// Per-region pass. Homogeneous clusters must not carry per-region machine
+	// values (clear them); heterogeneous clusters resolve each region BY NAME so
+	// the computed sibling comes from the same-named state region (correct even
+	// when the list is reordered) and is set unknown on a resize.
+	for i := range plan.Regions {
+		var newVCPUs types.Int64
+		var newMT types.String
+		if !heterogeneous {
+			newVCPUs, newMT = types.Int64Null(), types.StringNull()
+		} else {
+			regionConfig, ok := configByName[plan.Regions[i].Name.ValueString()]
+			if !ok {
+				continue
+			}
+			regionState, hasState := stateByName[plan.Regions[i].Name.ValueString()]
+			var stateVCPUs types.Int64
+			var stateMT types.String
+			if hasState {
+				stateVCPUs, stateMT = regionState.NumVirtualCpus, regionState.MachineType
+			}
+			var regionChanged bool
+			newVCPUs, newMT, regionChanged = resolveMachinePlan(regionConfig.NumVirtualCpus, regionConfig.MachineType, stateVCPUs, stateMT, hasState)
+			resizing = resizing || regionChanged
+		}
+		if !newVCPUs.Equal(plan.Regions[i].NumVirtualCpus) {
+			plan.Regions[i].NumVirtualCpus = newVCPUs
+			changed = true
+		}
+		if !newMT.Equal(plan.Regions[i].MachineType) {
+			plan.Regions[i].MachineType = newMT
+			changed = true
+		}
+	}
+
+	// A removed region (in state, absent from config) can shift a heterogeneous
+	// cluster's cluster-wide aggregates (the API reports the most common per-region
+	// value), so treat a removal as a resize. Additions are already handled above:
+	// a new region has no state, so resolveMachinePlan sets resizing.
+	if heterogeneous {
+		for name := range stateByName {
+			if _, ok := configByName[name]; !ok {
+				resizing = true
+				break
+			}
+		}
+	}
+
+	// Cluster-wide pass (homogeneous only; heterogeneous cluster-wide fields are
+	// derived aggregates handled by the resizing block below).
+	if !heterogeneous && state.DedicatedConfig != nil {
+		newVCPUs, newMT, clusterChanged := resolveMachinePlan(
+			config.DedicatedConfig.NumVirtualCpus, config.DedicatedConfig.MachineType,
+			state.DedicatedConfig.NumVirtualCpus, state.DedicatedConfig.MachineType, true,
+		)
+		if !newVCPUs.Equal(plan.DedicatedConfig.NumVirtualCpus) {
+			plan.DedicatedConfig.NumVirtualCpus = newVCPUs
+			changed = true
+		}
+		if !newMT.Equal(plan.DedicatedConfig.MachineType) {
+			plan.DedicatedConfig.MachineType = newMT
+			changed = true
+		}
+		resizing = resizing || clusterChanged
+	}
+
+	if resizing {
+		// memory_gib is derived from the machine type and changes on resize.
+		plan.DedicatedConfig.MemoryGib = types.Float64Unknown()
+		if heterogeneous {
+			// The cluster-wide num_virtual_cpus/machine_type are derived aggregates
+			// for a heterogeneous cluster and may shift when any region changes.
+			plan.DedicatedConfig.NumVirtualCpus = types.Int64Unknown()
+			plan.DedicatedConfig.MachineType = types.StringUnknown()
+		}
+		changed = true
+	}
+	return changed
+}
+
+// machineSpecFrom builds a DedicatedMachineTypeSpecification from a
+// (num_virtual_cpus, machine_type) pair, preferring num_virtual_cpus (the
+// recommended field) when both are known. Returns an empty spec when neither is
+// known.
+func machineSpecFrom(numVCPUs types.Int64, machineType types.String) client.DedicatedMachineTypeSpecification {
+	spec := client.DedicatedMachineTypeSpecification{}
+	switch {
+	case IsKnown(numVCPUs):
+		cpus := int32(numVCPUs.ValueInt64())
+		spec.NumVirtualCpus = &cpus
+	case IsKnown(machineType):
+		mt := machineType.ValueString()
+		spec.MachineType = &mt
+	}
+	return spec
+}
+
+// buildRegionMachineSpecs builds the per-region machine type map for a
+// heterogeneous Advanced cluster. It returns the map and true when at least one
+// region specifies num_virtual_cpus or machine_type (validated all-or-none in
+// ValidateConfig); otherwise it returns false and the caller should fall back to
+// the cluster-wide hardware.machine_spec path.
+//
+// Callers must pass the regions from the raw CONFIG, not the plan. Plan modifiers
+// (UseStateForUnknown/SuppressMachineTypeDrift) carry prior per-region values
+// forward into the plan even after the user removes them from config; using the
+// plan would make a switch back to cluster-wide sizing silently send stale
+// per-region specs instead.
+func buildRegionMachineSpecs(regions []Region) (map[string]client.DedicatedMachineTypeSpecification, bool) {
+	specs := make(map[string]client.DedicatedMachineTypeSpecification, len(regions))
+	found := false
+	for _, region := range regions {
+		if !hasRegionMachineType(region) {
+			continue
+		}
+		specs[region.Name.ValueString()] = machineSpecFrom(region.NumVirtualCpus, region.MachineType)
+		found = true
+	}
+	return specs, found
+}
+
+// buildClusterWideMachineSpec builds the cluster-wide machine type spec for a
+// homogeneous Advanced cluster. It prefers what the user set in config so an
+// explicit num_virtual_cpus/machine_type change is honored, and falls back to the
+// plan's carried-forward value (e.g. SuppressMachineTypeDrift) when config
+// specifies neither, so the current machine type is still sent. At create time
+// config == plan, so this matches the create path as well.
+func buildClusterWideMachineSpec(config, plan *DedicatedClusterConfig) client.DedicatedMachineTypeSpecification {
+	if config != nil && (IsKnown(config.NumVirtualCpus) || IsKnown(config.MachineType)) {
+		return machineSpecFrom(config.NumVirtualCpus, config.MachineType)
+	}
+	if plan != nil {
+		return machineSpecFrom(plan.NumVirtualCpus, plan.MachineType)
+	}
+	return client.DedicatedMachineTypeSpecification{}
+}
+
+func getManagedRegions(
+	apiRegions *[]client.Region,
+	plan []Region,
+	cloudProvider client.CloudProviderType,
+	diags *diag.Diagnostics,
+) []Region {
 	if apiRegions == nil {
 		return nil
 	}
 	regions := make([]Region, 0, len(*apiRegions))
 	sortRegionsByPlan(apiRegions, plan)
-	planRegions := make(map[string]bool, len(plan))
-	for _, region := range plan {
-		planRegions[region.Name.ValueString()] = true
+	planRegions := make(map[string]*Region, len(plan))
+	for i := range plan {
+		planRegions[plan[i].Name.ValueString()] = &plan[i]
 	}
 	isDatasourceOrImport := len(plan) == 0
 	for _, x := range *apiRegions {
-		if isDatasourceOrImport || planRegions[x.Name] {
-			rg := Region{
-				Name:               types.StringValue(x.Name),
-				SqlDns:             types.StringValue(x.SqlDns),
-				UiDns:              types.StringValue(x.UiDns),
-				InternalDns:        types.StringValue(x.InternalDns),
-				PrivateEndpointDns: types.StringValue(x.PrivateEndpointDns),
-				NodeCount:          types.Int64Value(int64(x.NodeCount)),
-				Primary:            types.BoolValue(x.GetPrimary()),
-				S3VpcEndpointId:    types.StringValue(x.GetS3VpcEndpointId()),
-			}
-			regions = append(regions, rg)
+		planRegion, managed := planRegions[x.Name]
+		if !isDatasourceOrImport && !managed {
+			continue
 		}
+		rg := Region{
+			Name:               types.StringValue(x.Name),
+			SqlDns:             types.StringValue(x.SqlDns),
+			UiDns:              types.StringValue(x.UiDns),
+			InternalDns:        types.StringValue(x.InternalDns),
+			PrivateEndpointDns: types.StringValue(x.PrivateEndpointDns),
+			NodeCount:          types.Int64Value(int64(x.NodeCount)),
+			NumVirtualCpus:     types.Int64Null(),
+			MachineType:        types.StringNull(),
+			Primary:            types.BoolValue(x.GetPrimary()),
+			S3VpcEndpointId:    types.StringValue(x.GetS3VpcEndpointId()),
+		}
+
+		// Per-region machine types are only surfaced when the user manages them
+		// per region (heterogeneous cluster) or when importing / reading a data
+		// source. For homogeneous clusters the machine type lives in the
+		// cluster-wide dedicated block, so these fields stay null to avoid drift.
+		if isDatasourceOrImport {
+			if x.NumVirtualCpus != nil {
+				rg.NumVirtualCpus = types.Int64Value(int64(*x.NumVirtualCpus))
+			}
+			if x.MachineType != nil {
+				rg.MachineType = types.StringValue(*x.MachineType)
+			}
+		} else if IsKnown(planRegion.NumVirtualCpus) || IsKnown(planRegion.MachineType) {
+			// The user manages this region per-region. Populate BOTH fields from
+			// the API (mirroring the cluster-wide path) so the recommended
+			// num_virtual_cpus-only path doesn't leave machine_type null, which
+			// would show a perpetual "(known after apply)". When the server omits
+			// a field, fall back to the planned value so state matches the plan
+			// and we don't produce an inconsistent result after apply.
+			if x.NumVirtualCpus != nil {
+				rg.NumVirtualCpus = types.Int64Value(int64(*x.NumVirtualCpus))
+			} else if IsKnown(planRegion.NumVirtualCpus) {
+				rg.NumVirtualCpus = planRegion.NumVirtualCpus
+			}
+			if x.MachineType != nil {
+				rg.MachineType = suppressMachineTypeDrift(
+					planRegion.MachineType, *x.MachineType, x.Name, cloudProvider, diags)
+			} else if IsKnown(planRegion.MachineType) {
+				rg.MachineType = planRegion.MachineType
+			}
+		}
+
+		regions = append(regions, rg)
 	}
 	return regions
+}
+
+// suppressMachineTypeDrift handles server-side machine type conversions: when the
+// server has converted the instance family to one with the same vCPU count (e.g.
+// m6i→m7g), the plan value is preserved and a warning is emitted; otherwise the API
+// value is returned so genuine changes surface as normal drift. Passing a
+// regionName produces a per-region warning; an empty regionName produces the
+// cluster-wide warning.
+func suppressMachineTypeDrift(
+	planMachineType types.String,
+	apiMachineType string,
+	regionName string,
+	cloudProvider client.CloudProviderType,
+	diags *diag.Diagnostics,
+) types.String {
+	planMT := planMachineType.ValueString()
+	if planMT == apiMachineType {
+		return types.StringValue(apiMachineType)
+	}
+	planVCPUs, planOk := extractVCPUCount(cloudProvider, planMT)
+	apiVCPUs, apiOk := extractVCPUCount(cloudProvider, apiMachineType)
+	if planOk && apiOk && planVCPUs == apiVCPUs {
+		if diags != nil {
+			detail := fmt.Sprintf(
+				"The server is running machine_type %q instead of %q (same vCPU count: %d). "+
+					"Update your configuration to use %q to remove this warning.",
+				apiMachineType, planMT, planVCPUs, apiMachineType,
+			)
+			if regionName != "" {
+				detail = fmt.Sprintf("[Region %s]: %s", regionName, detail)
+			}
+			diags.AddWarning("Machine type converted by server", detail)
+		}
+		return planMachineType
+	}
+	return types.StringValue(apiMachineType)
 }
 
 func waitForClusterReadyFunc(

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	framework_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -53,6 +54,11 @@ const (
 	serverlessDataSourceName = "data.cockroach_cluster.test"
 
 	defaultPlanType = ""
+
+	// CockroachHeterogeneousEnabled gates acceptance tests for per-region
+	// (heterogeneous) machine types, which require a limited-access feature flag on
+	// the test organization.
+	CockroachHeterogeneousEnabled string = "COCKROACH_HETEROGENEOUS_ENABLED"
 )
 
 var httpOk = &http.Response{Status: http.StatusText(http.StatusOK)}
@@ -2540,6 +2546,1133 @@ data "cockroach_cluster" "test" {
 	})
 }
 
+// skipUnlessHeterogeneousEnabled skips heterogeneous machine type acceptance tests
+// unless COCKROACH_HETEROGENEOUS_ENABLED is set, since the feature is limited-access
+// and only usable in a flag-enabled organization.
+func skipUnlessHeterogeneousEnabled(t *testing.T) {
+	if os.Getenv(CockroachHeterogeneousEnabled) == "" {
+		t.Skip("COCKROACH_HETEROGENEOUS_ENABLED is not set; skipping heterogeneous machine type acceptance test")
+	}
+}
+
+// TestAccDedicatedClusterHeterogeneous creates a heterogeneous Advanced cluster
+// (per-region num_virtual_cpus) against the real API and verifies the values
+// round-trip with no drift on re-plan.
+func TestAccDedicatedClusterHeterogeneous(t *testing.T) {
+	skipUnlessHeterogeneousEnabled(t)
+	t.Parallel()
+	clusterName := fmt.Sprintf("%s-hetero-%s", tfTestPrefix, GenerateRandomString(3))
+
+	cfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "GCP"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    { name = "us-central1", node_count = 3, num_virtual_cpus = 4 },
+    { name = "us-east1", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-west1", node_count = 3, num_virtual_cpus = 8 },
+  ]
+}
+
+data "cockroach_cluster" "test" {
+  id = cockroach_cluster.test.id
+}
+`, clusterName)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               false,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCockroachClusterExists("cockroach_cluster.test"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.num_virtual_cpus", "8"),
+					// machine_type is derived and populated from the API even though
+					// the user configured only num_virtual_cpus.
+					resource.TestCheckResourceAttrSet("cockroach_cluster.test", "regions.0.machine_type"),
+					resource.TestCheckResourceAttr("data.cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDedicatedClusterHomogeneousToHeterogeneous creates a homogeneous Advanced
+// cluster and then switches it to per-region (heterogeneous) sizing, exercising the
+// real resize path where the cluster-wide num_virtual_cpus/machine_type aggregates
+// shift.
+func TestAccDedicatedClusterHomogeneousToHeterogeneous(t *testing.T) {
+	skipUnlessHeterogeneousEnabled(t)
+	t.Parallel()
+	clusterName := fmt.Sprintf("%s-homo2het-%s", tfTestPrefix, GenerateRandomString(3))
+
+	homogeneousCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "GCP"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib      = 15
+    num_virtual_cpus = 4
+  }
+  regions = [
+    { name = "us-central1", node_count = 3 },
+    { name = "us-east1", node_count = 3 },
+    { name = "us-west1", node_count = 3 },
+  ]
+}
+`, clusterName)
+
+	heterogeneousCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "GCP"
+  plan           = "ADVANCED"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    { name = "us-central1", node_count = 3, num_virtual_cpus = 4 },
+    { name = "us-east1", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-west1", node_count = 3, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               false,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: homogeneousCfg,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCockroachClusterExists("cockroach_cluster.test"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.num_virtual_cpus", "4"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.#", "3"),
+				),
+			},
+			{
+				Config: heterogeneousCfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.num_virtual_cpus", "8"),
+					resource.TestCheckResourceAttrSet("cockroach_cluster.test", "regions.1.machine_type"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterPerRegionMachineType validates that a
+// heterogeneous Advanced cluster sends per-region machine specs
+// (region_machine_specs) in the create request and omits the cluster-wide
+// hardware.machine_spec, and that the per-region values round-trip into state.
+func TestIntegrationDedicatedClusterPerRegionMachineType(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-dedicated-hetero-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	// The API echoes a machine_type per region (as a real heterogeneous cluster
+	// does), even though the user only configured num_virtual_cpus.
+	mtSmall := "m6i.xlarge"
+	mtLarge := "m6i.2xlarge"
+	cluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{
+				NumVirtualCpus: 4,
+				StorageGib:     15,
+				MemoryGib:      8,
+			},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+			{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+		},
+	}
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *client.CreateClusterRequest) (*client.Cluster, *http.Response, error) {
+			ded := req.Spec.Dedicated
+			if ded == nil {
+				return nil, nil, fmt.Errorf("missing dedicated spec")
+			}
+			if ded.RegionMachineSpecs == nil {
+				return nil, nil, fmt.Errorf("expected region_machine_specs to be set")
+			}
+			specs := *ded.RegionMachineSpecs
+			if specs["us-east-1"].NumVirtualCpus == nil || *specs["us-east-1"].NumVirtualCpus != 4 {
+				return nil, nil, fmt.Errorf("unexpected us-east-1 spec: %+v", specs["us-east-1"])
+			}
+			if specs["us-west-2"].NumVirtualCpus == nil || *specs["us-west-2"].NumVirtualCpus != 8 {
+				return nil, nil, fmt.Errorf("unexpected us-west-2 spec: %+v", specs["us-west-2"])
+			}
+			if len(specs) != 3 {
+				return nil, nil, fmt.Errorf("expected 3 region specs, got %d", len(specs))
+			}
+			if ded.Hardware.MachineSpec != nil {
+				return nil, nil, fmt.Errorf("expected hardware.machine_spec to be nil in heterogeneous mode")
+			}
+			return &cluster, httpOk, nil
+		},
+	)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).
+		Return(&cluster, httpOk, nil).AnyTimes()
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	cfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 1, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.num_virtual_cpus", "8"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.2.num_virtual_cpus", "8"),
+					// machine_type is populated from the API even though the user
+					// only set num_virtual_cpus, mirroring the cluster-wide path.
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.machine_type", "m6i.xlarge"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.machine_type", "m6i.2xlarge"),
+				),
+			},
+			{
+				// Re-applying the identical config must produce an empty plan. This
+				// guards against the per-region machine_type showing a perpetual
+				// "(known after apply)" for num_virtual_cpus users.
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterHeterogeneousToHomogeneous switches a
+// heterogeneous Advanced cluster back to cluster-wide (homogeneous) sizing and
+// asserts the resulting update request.
+func TestIntegrationDedicatedClusterHeterogeneousToHomogeneous(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-het2homo-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	mtSmall := "m6i.xlarge"
+	mtLarge := "m6i.2xlarge"
+
+	// Heterogeneous starting point: per-region specs, with the API reporting a
+	// cluster-wide aggregate (the most common per-region value) in Config.Dedicated.
+	heteroCluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: 8, StorageGib: 15, MemoryGib: 16},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+			{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+		},
+	}
+
+	// After switching to cluster-wide 8 vCPU sizing the whole cluster is uniform.
+	homoCluster := heteroCluster
+	homoCluster.Config.Dedicated = &client.DedicatedHardwareConfig{NumVirtualCpus: 8, StorageGib: 15, MemoryGib: 16}
+	homoCluster.Regions = []client.Region{
+		{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+		{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+		{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+	}
+
+	// current tracks what GetCluster returns; UpdateCluster flips it to homogeneous.
+	current := heteroCluster
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&heteroCluster, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).
+		DoAndReturn(func(context.Context, string) (*client.Cluster, *http.Response, error) {
+			c := current
+			return &c, httpOk, nil
+		}).AnyTimes()
+
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil {
+				return nil, nil, fmt.Errorf("expected a dedicated update spec")
+			}
+			// The switch-back must not carry forward per-region specs from state.
+			if ded.RegionMachineSpecs != nil {
+				return nil, nil, fmt.Errorf("expected no region_machine_specs when switching to homogeneous, got %+v", *ded.RegionMachineSpecs)
+			}
+			if ded.Hardware == nil || ded.Hardware.MachineSpec == nil {
+				return nil, nil, fmt.Errorf("expected a cluster-wide hardware.machine_spec")
+			}
+			ms := ded.Hardware.MachineSpec
+			if ms.NumVirtualCpus == nil || *ms.NumVirtualCpus != 8 {
+				return nil, nil, fmt.Errorf("expected cluster-wide machine_spec of 8 vCPUs, got %+v", *ms)
+			}
+			current = homoCluster
+			return &homoCluster, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	heteroCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = {
+    storage_gib = 15
+  }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 1, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	homoCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = {
+    storage_gib      = 15
+    num_virtual_cpus = 8
+  }
+  regions = [
+    { name = "us-east-1", node_count = 1 },
+    { name = "us-east-2", node_count = 1 },
+    { name = "us-west-2", node_count = 1 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: heteroCfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.num_virtual_cpus", "8"),
+				),
+			},
+			{
+				Config: homoCfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.num_virtual_cpus", "8"),
+					// The per-region machine fields must clear on the switch-back.
+					resource.TestCheckNoResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterPerRegionUnknownValue verifies that the
+// all-or-none validation does not fire falsely when a per-region machine value is
+// an unresolved reference at plan time (unknown, not null). Here one region's
+// num_virtual_cpus comes from a terraform_data output, which is unknown until
+// apply.
+func TestIntegrationDedicatedClusterPerRegionUnknownValue(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-hetero-unknown-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	cluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: 4, StorageGib: 15, MemoryGib: 8},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu4},
+			{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+			{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+		},
+	}
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&cluster, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).
+		Return(&cluster, httpOk, nil).AnyTimes()
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	// terraform_data.cpus.output is unknown at plan time (the resource doesn't
+	// exist yet), so regions[1].num_virtual_cpus is unknown during validation.
+	cfg := fmt.Sprintf(`
+resource "terraform_data" "cpus" {
+  input = 8
+}
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = terraform_data.cpus.output },
+    { name = "us-west-2", node_count = 1, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.1.num_virtual_cpus", "8"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterPerRegionMachineTypeValidation validates the
+// mutual-exclusivity and all-or-none rules for per-region machine types. These
+// fail during plan/validation, before any API call.
+func TestIntegrationDedicatedClusterPerRegionMachineTypeValidation(t *testing.T) {
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	clusterName := fmt.Sprintf("%s-hetero-val-%s", tfTestPrefix, GenerateRandomString(3))
+
+	cases := []struct {
+		name        string
+		config      string
+		expectError *regexp.Regexp
+	}{
+		{
+			name: "both num_virtual_cpus and machine_type in a region",
+			config: fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "AWS"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4, machine_type = "m6i.xlarge" },
+  ]
+}
+`, clusterName),
+			expectError: regexp.MustCompile(`mutually exclusive within a region`),
+		},
+		{
+			name: "mixing cluster-wide and per-region",
+			config: fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "AWS"
+  dedicated = { storage_gib = 15, num_virtual_cpus = 4 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+  ]
+}
+`, clusterName),
+			expectError: regexp.MustCompile(`not both`),
+		},
+		{
+			name: "partial per-region violates all-or-none",
+			config: fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name           = "%s"
+  cloud_provider = "AWS"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 1 },
+  ]
+}
+`, clusterName),
+			expectError: regexp.MustCompile(`every region must`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				IsUnitTest:               true,
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config:      tc.config,
+						ExpectError: tc.expectError,
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestIntegrationDedicatedClusterPerRegionToClusterWide is a regression test for
+// the case where a heterogeneous cluster is switched back to cluster-wide sizing.
+// Plan modifiers carry the prior per-region values forward into the plan even
+// after the user removes them from config, so the switch must be decided from
+// config: the update must send the cluster-wide hardware.machine_spec (not stale
+// region_machine_specs), and the post-apply read must not resurrect per-region
+// values (which would cause an "inconsistent result after apply" error).
+func TestIntegrationDedicatedClusterPerRegionToClusterWide(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-hetero-switch-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	heteroCluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: 4, StorageGib: 15, MemoryGib: 8},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu4},
+			{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+			{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+		},
+	}
+	// After the switch, the cluster is homogeneous at 8 vCPUs. The API still
+	// reports per-region num_virtual_cpus (all equal), which must NOT leak into
+	// state because the user is no longer managing them per region.
+	homoCluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: 8, StorageGib: 15, MemoryGib: 16},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &vcpu8},
+			{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+			{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8},
+		},
+	}
+	current := &heteroCluster
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&heteroCluster, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil || ded.Hardware == nil {
+				return nil, nil, fmt.Errorf("missing dedicated/hardware in update")
+			}
+			if ded.RegionMachineSpecs != nil {
+				return nil, nil, fmt.Errorf("expected region_machine_specs to be nil when switching to cluster-wide, got %+v", *ded.RegionMachineSpecs)
+			}
+			if ded.Hardware.MachineSpec == nil || ded.Hardware.MachineSpec.NumVirtualCpus == nil || *ded.Hardware.MachineSpec.NumVirtualCpus != 8 {
+				return nil, nil, fmt.Errorf("expected cluster-wide machine_spec num_virtual_cpus=8, got %+v", ded.Hardware.MachineSpec)
+			}
+			current = &homoCluster
+			return &homoCluster, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	heteroCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 1, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	homoCfg := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15, num_virtual_cpus = 8 }
+  regions = [
+    { name = "us-east-1", node_count = 1 },
+    { name = "us-east-2", node_count = 1 },
+    { name = "us-west-2", node_count = 1 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: heteroCfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+				),
+			},
+			{
+				Config: homoCfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.num_virtual_cpus", "8"),
+					resource.TestCheckNoResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterPerRegionResize is the regression test for the
+// resize inconsistency: changing one region's num_virtual_cpus must not leave a
+// stale machine_type in the plan (carried by SuppressMachineTypeDrift) that the
+// resize invalidates, which would produce "Provider produced inconsistent result
+// after apply".
+func TestIntegrationDedicatedClusterPerRegionResize(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-hetero-resize-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	mtSmall := "m6i.xlarge"
+	mtLarge := "m6i.2xlarge"
+	baseCluster := func(eastVCPUs int32, eastMT string) client.Cluster {
+		e := eastVCPUs
+		return client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: eastVCPUs, StorageGib: 15, MemoryGib: 8},
+			},
+			Regions: []client.Region{
+				{Name: "us-east-1", NodeCount: 1, NumVirtualCpus: &e, MachineType: &eastMT},
+				{Name: "us-east-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+				{Name: "us-west-2", NodeCount: 1, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			},
+		}
+	}
+	hetero := baseCluster(vcpu4, mtSmall)
+	resized := baseCluster(vcpu8, mtLarge)
+	// The resize changes the cluster-wide derived memory too.
+	resized.Config.Dedicated.MemoryGib = 16
+	current := &hetero
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&hetero, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil || ded.RegionMachineSpecs == nil {
+				return nil, nil, fmt.Errorf("expected region_machine_specs on resize")
+			}
+			specs := *ded.RegionMachineSpecs
+			if specs["us-east-1"].NumVirtualCpus == nil || *specs["us-east-1"].NumVirtualCpus != 8 {
+				return nil, nil, fmt.Errorf("expected us-east-1 resized to 8 vCPUs, got %+v", specs["us-east-1"])
+			}
+			current = &resized
+			return &resized, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	cfg := func(eastVCPUs int) string {
+		return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 1, num_virtual_cpus = %d },
+    { name = "us-east-2", node_count = 1, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 1, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion, eastVCPUs)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(4),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "4"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.machine_type", "m6i.xlarge"),
+				),
+			},
+			{
+				// Resize us-east-1 4 -> 8. Must apply cleanly (no inconsistent
+				// result) and land the new machine_type in state.
+				Config: cfg(8),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "8"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.machine_type", "m6i.2xlarge"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterPerRegionRemove is the regression test for the
+// region-removal path: the CC API reports the cluster-wide num_virtual_cpus/
+// machine_type as the most common per-region value, so removing a region can shift
+// that aggregate. ModifyPlan must treat a removal as a resize and mark the
+// cluster-wide derived fields unknown, or apply fails with "inconsistent result
+// after apply". Starts at 4 regions so the removal leaves 3 (never a 2-region
+// cluster).
+func TestIntegrationDedicatedClusterPerRegionRemove(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-hetero-remove-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	mtSmall := "m6i.xlarge"
+	mtLarge := "m6i.2xlarge"
+	// Initial cluster: two 8-vCPU and two 4-vCPU regions; the API reports the
+	// cluster-wide aggregate as 8 / m6i.2xlarge / 16 GiB.
+	base := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{MachineType: mtLarge, NumVirtualCpus: 8, StorageGib: 15, MemoryGib: 16},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-1", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			{Name: "us-east-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			{Name: "us-west-1", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+			{Name: "us-west-2", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+		},
+	}
+	// After removing us-east-1 (an 8-vCPU region), the plurality flips to 4, so the
+	// API's reported cluster-wide aggregate shifts to 4 / m6i.xlarge / 8 GiB.
+	afterRemoval := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: minSupportedClusterPatchVersion,
+		Plan:             client.PLANTYPE_ADVANCED,
+		CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+		State:            client.CLUSTERSTATETYPE_CREATED,
+		Config: client.ClusterConfig{
+			Dedicated: &client.DedicatedHardwareConfig{MachineType: mtSmall, NumVirtualCpus: 4, StorageGib: 15, MemoryGib: 8},
+		},
+		Regions: []client.Region{
+			{Name: "us-east-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			{Name: "us-west-1", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+			{Name: "us-west-2", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+		},
+	}
+	current := &base
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&base, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil || ded.RegionNodes == nil {
+				return nil, nil, fmt.Errorf("expected region_nodes on region removal")
+			}
+			if _, ok := (*ded.RegionNodes)["us-east-1"]; ok {
+				return nil, nil, fmt.Errorf("expected region_nodes to omit the removed region us-east-1, got %v", *ded.RegionNodes)
+			}
+			current = &afterRemoval
+			return &afterRemoval, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	fourRegions := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-east-2", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-west-1", node_count = 3, num_virtual_cpus = 4 },
+    { name = "us-west-2", node_count = 3, num_virtual_cpus = 4 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+	threeRegions := fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-2", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-west-1", node_count = 3, num_virtual_cpus = 4 },
+    { name = "us-west-2", node_count = 3, num_virtual_cpus = 4 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fourRegions,
+				Check:  resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.#", "4"),
+			},
+			{
+				// Removing us-east-1 shifts the cluster-wide aggregate; the apply
+				// must succeed (no inconsistent result) and land 3 regions.
+				Config: threeRegions,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.#", "3"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.num_virtual_cpus", "8"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterClusterWideResize guards the same inconsistency
+// on the cluster-wide path: a num_virtual_cpus resize must recompute the
+// cluster-wide machine_type rather than carry the stale value forward.
+func TestIntegrationDedicatedClusterClusterWideResize(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-homo-resize-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	homo := func(vcpus int32, mt string) client.Cluster {
+		return client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{MachineType: mt, NumVirtualCpus: vcpus, StorageGib: 15, MemoryGib: 8},
+			},
+			Regions: []client.Region{{Name: "us-east-1", NodeCount: 1}},
+		}
+	}
+	small := homo(4, "m6i.xlarge")
+	large := homo(8, "m6i.2xlarge")
+	large.Config.Dedicated.MemoryGib = 16
+	current := &small
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&small, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil || ded.Hardware == nil || ded.Hardware.MachineSpec == nil {
+				return nil, nil, fmt.Errorf("expected cluster-wide machine_spec on resize")
+			}
+			if ded.Hardware.MachineSpec.NumVirtualCpus == nil || *ded.Hardware.MachineSpec.NumVirtualCpus != 8 {
+				return nil, nil, fmt.Errorf("expected cluster-wide resize to 8 vCPUs, got %+v", ded.Hardware.MachineSpec)
+			}
+			current = &large
+			return &large, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	cfg := func(vcpus int) string {
+		return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15, num_virtual_cpus = %d }
+  regions = [{ name = "us-east-1", node_count = 1 }]
+}
+`, clusterName, minSupportedClusterMajorVersion, vcpus)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(4),
+				Check:  resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.machine_type", "m6i.xlarge"),
+			},
+			{
+				Config: cfg(8),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.num_virtual_cpus", "8"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.machine_type", "m6i.2xlarge"),
+				),
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterHeterogeneousWithCMEKRegion verifies that when a
+// region managed by a separate resource (e.g. CMEK) is present on the cluster but
+// not in this resource's config, an update sends region_machine_specs covering only
+// the config regions while region_nodes includes the externally-managed region. The
+// API contract (SDK: "unnamed regions retain their current machine type") makes the
+// partial map safe.
+func TestIntegrationDedicatedClusterHeterogeneousWithCMEKRegion(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-hetero-cmek-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	mtSmall := "m6i.xlarge"
+	mtLarge := "m6i.2xlarge"
+	// The cluster has three config-managed regions plus us-central-1, which is
+	// managed externally (CMEK) and never appears in this resource's config.
+	mkCluster := func(eastNodes int32) client.Cluster {
+		e := eastNodes
+		return client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{NumVirtualCpus: 4, StorageGib: 15, MemoryGib: 8},
+			},
+			Regions: []client.Region{
+				{Name: "us-east-1", NodeCount: e, NumVirtualCpus: &vcpu4, MachineType: &mtSmall},
+				{Name: "us-east-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+				{Name: "us-west-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+				{Name: "us-central-1", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtLarge},
+			},
+		}
+	}
+	base := mkCluster(3)
+	resized := mkCluster(4)
+	current := &base
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(&base, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, spec *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			ded := spec.Dedicated
+			if ded == nil || ded.RegionNodes == nil || ded.RegionMachineSpecs == nil {
+				return nil, nil, fmt.Errorf("expected region_nodes and region_machine_specs to be set")
+			}
+			nodes := *ded.RegionNodes
+			specs := *ded.RegionMachineSpecs
+			if _, ok := nodes["us-central-1"]; !ok {
+				return nil, nil, fmt.Errorf("expected region_nodes to include the CMEK region us-central-1, got %v", nodes)
+			}
+			if _, ok := specs["us-central-1"]; ok {
+				return nil, nil, fmt.Errorf("expected region_machine_specs to omit the CMEK region us-central-1, got %v", specs)
+			}
+			if len(specs) != 3 {
+				return nil, nil, fmt.Errorf("expected 3 region_machine_specs (config regions only), got %d", len(specs))
+			}
+			current = &resized
+			return &resized, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	cfg := func(eastNodes int) string {
+		return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15 }
+  regions = [
+    { name = "us-east-1", node_count = %d, num_virtual_cpus = 4 },
+    { name = "us-east-2", node_count = 3, num_virtual_cpus = 8 },
+    { name = "us-west-2", node_count = 3, num_virtual_cpus = 8 },
+  ]
+}
+`, clusterName, minSupportedClusterMajorVersion, eastNodes)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(3),
+				Check: resource.ComposeTestCheckFunc(
+					// The externally-managed region is filtered out of this
+					// resource's state.
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.#", "3"),
+				),
+			},
+			{
+				// Change us-east-1 node_count to force a region update; the CMEK
+				// region flows into region_nodes but not region_machine_specs.
+				Config: cfg(4),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "regions.0.node_count", "4"),
+				),
+			},
+		},
+	})
+}
+
 func testDedicatedClusterResource(
 	t *testing.T, clusterName string, useMock bool, additionalSteps ...resource.TestStep,
 ) {
@@ -2893,7 +4026,8 @@ func TestGetManagedRegionsS3VpcEndpointId(t *testing.T) {
 		plan := []Region{
 			{Name: types.StringValue("us-east-1")},
 		}
-		result := getManagedRegions(&regions, plan)
+		var diags diag.Diagnostics
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_AWS, &diags)
 		require.Len(t, result, 1)
 		require.Equal(t, "vpce-0abc123def456", result[0].S3VpcEndpointId.ValueString())
 	})
@@ -2911,7 +4045,8 @@ func TestGetManagedRegionsS3VpcEndpointId(t *testing.T) {
 		plan := []Region{
 			{Name: types.StringValue("us-central1")},
 		}
-		result := getManagedRegions(&regions, plan)
+		var diags diag.Diagnostics
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_GCP, &diags)
 		require.Len(t, result, 1)
 		require.Equal(t, "", result[0].S3VpcEndpointId.ValueString())
 	})
@@ -2925,9 +4060,288 @@ func TestGetManagedRegionsS3VpcEndpointId(t *testing.T) {
 				S3VpcEndpointId: &vpceid,
 			},
 		}
-		result := getManagedRegions(&regions, nil)
+		var diags diag.Diagnostics
+		result := getManagedRegions(&regions, nil, client.CLOUDPROVIDERTYPE_AWS, &diags)
 		require.Len(t, result, 1)
 		require.Equal(t, "vpce-0def456abc789", result[0].S3VpcEndpointId.ValueString())
+	})
+}
+
+func TestBuildRegionMachineSpecs(t *testing.T) {
+	t.Run("no per-region specs returns false", func(t *testing.T) {
+		regions := []Region{
+			{Name: types.StringValue("us-east-1")},
+			{Name: types.StringValue("us-east-2")},
+			{Name: types.StringValue("us-west-2")},
+		}
+		specs, ok := buildRegionMachineSpecs(regions)
+		require.False(t, ok)
+		require.Empty(t, specs)
+	})
+
+	t.Run("num_virtual_cpus per region", func(t *testing.T) {
+		regions := []Region{
+			{Name: types.StringValue("us-east-1"), NumVirtualCpus: types.Int64Value(4)},
+			{Name: types.StringValue("us-east-2"), NumVirtualCpus: types.Int64Value(8)},
+			{Name: types.StringValue("us-west-2"), NumVirtualCpus: types.Int64Value(8)},
+		}
+		specs, ok := buildRegionMachineSpecs(regions)
+		require.True(t, ok)
+		require.Len(t, specs, 3)
+		require.Equal(t, int32(4), *specs["us-east-1"].NumVirtualCpus)
+		require.Nil(t, specs["us-east-1"].MachineType)
+		require.Equal(t, int32(8), *specs["us-west-2"].NumVirtualCpus)
+	})
+
+	t.Run("machine_type per region", func(t *testing.T) {
+		regions := []Region{
+			{Name: types.StringValue("us-east-1"), MachineType: types.StringValue("m6i.xlarge")},
+			{Name: types.StringValue("us-east-2"), MachineType: types.StringValue("m6i.2xlarge")},
+			{Name: types.StringValue("us-west-2"), MachineType: types.StringValue("m6i.2xlarge")},
+		}
+		specs, ok := buildRegionMachineSpecs(regions)
+		require.True(t, ok)
+		require.Len(t, specs, 3)
+		require.Equal(t, "m6i.xlarge", *specs["us-east-1"].MachineType)
+		require.Nil(t, specs["us-east-1"].NumVirtualCpus)
+	})
+}
+
+func TestGetManagedRegionsMachineType(t *testing.T) {
+	vcpu4 := int32(4)
+	vcpu8 := int32(8)
+	mtEast := "m6i.xlarge"
+	mtWest := "m6i.2xlarge"
+	apiRegions := func() []client.Region {
+		return []client.Region{
+			{Name: "us-east-1", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &mtEast},
+			{Name: "us-east-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtWest},
+			{Name: "us-west-2", NodeCount: 3, NumVirtualCpus: &vcpu8, MachineType: &mtWest},
+		}
+	}
+
+	t.Run("num_virtual_cpus user gets machine_type populated from API", func(t *testing.T) {
+		// The recommended path: user sets only num_virtual_cpus per region. Both
+		// fields must be populated from the API (mirroring the cluster-wide path)
+		// so machine_type isn't left null (which would show perpetual drift).
+		plan := []Region{
+			{Name: types.StringValue("us-east-1"), NumVirtualCpus: types.Int64Value(4)},
+			{Name: types.StringValue("us-east-2"), NumVirtualCpus: types.Int64Value(8)},
+			{Name: types.StringValue("us-west-2"), NumVirtualCpus: types.Int64Value(8)},
+		}
+		var diags diag.Diagnostics
+		regions := apiRegions()
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_AWS, &diags)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(4), result[0].NumVirtualCpus.ValueInt64())
+		require.Equal(t, "m6i.xlarge", result[0].MachineType.ValueString())
+		require.Equal(t, int64(8), result[1].NumVirtualCpus.ValueInt64())
+		require.Equal(t, "m6i.2xlarge", result[1].MachineType.ValueString())
+	})
+
+	t.Run("falls back to plan value when API omits a field", func(t *testing.T) {
+		// The server echoes nil for a per-region field the user set (e.g. on a
+		// feature-flag/older-server edge). State must keep the planned value so we
+		// don't produce an "inconsistent result after apply".
+		regions := []client.Region{
+			{Name: "us-east-1", NodeCount: 3}, // NumVirtualCpus/MachineType nil
+		}
+		plan := []Region{
+			{Name: types.StringValue("us-east-1"), NumVirtualCpus: types.Int64Value(4)},
+		}
+		var diags diag.Diagnostics
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_AWS, &diags)
+		require.Len(t, result, 1)
+		require.Equal(t, int64(4), result[0].NumVirtualCpus.ValueInt64())
+		require.True(t, result[0].MachineType.IsNull())
+	})
+
+	t.Run("null when plan does not use per-region (homogeneous)", func(t *testing.T) {
+		plan := []Region{
+			{Name: types.StringValue("us-east-1")},
+			{Name: types.StringValue("us-east-2")},
+			{Name: types.StringValue("us-west-2")},
+		}
+		var diags diag.Diagnostics
+		regions := apiRegions()
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_AWS, &diags)
+		require.Len(t, result, 3)
+		require.True(t, result[0].NumVirtualCpus.IsNull())
+		require.True(t, result[0].MachineType.IsNull())
+	})
+
+	t.Run("datasource/import populates from API", func(t *testing.T) {
+		var diags diag.Diagnostics
+		regions := apiRegions()
+		result := getManagedRegions(&regions, nil, client.CLOUDPROVIDERTYPE_AWS, &diags)
+		require.Len(t, result, 3)
+		require.Equal(t, int64(4), result[0].NumVirtualCpus.ValueInt64())
+		require.Equal(t, "m6i.xlarge", result[0].MachineType.ValueString())
+	})
+
+	t.Run("machine_type drift suppressed when vCPU count matches", func(t *testing.T) {
+		converted := "m7g.xlarge" // same 4 vCPUs as configured m6i.xlarge
+		regions := []client.Region{
+			{Name: "us-east-1", NodeCount: 3, NumVirtualCpus: &vcpu4, MachineType: &converted},
+		}
+		plan := []Region{
+			{Name: types.StringValue("us-east-1"), MachineType: types.StringValue("m6i.xlarge")},
+		}
+		var diags diag.Diagnostics
+		result := getManagedRegions(&regions, plan, client.CLOUDPROVIDERTYPE_AWS, &diags)
+		require.Len(t, result, 1)
+		require.Equal(t, "m6i.xlarge", result[0].MachineType.ValueString())
+		require.True(t, diags.WarningsCount() > 0)
+	})
+}
+
+func TestResolveMachinePlan(t *testing.T) {
+	v4 := types.Int64Value(4)
+	v8 := types.Int64Value(8)
+	mtA := types.StringValue("m6i.xlarge")
+	mtB := types.StringValue("m6i.2xlarge")
+	nullI := types.Int64Null()
+	nullS := types.StringNull()
+
+	t.Run("num_virtual_cpus drives, unchanged -> machine_type from state", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(v4, nullS, v4, mtA, true)
+		require.Equal(t, v4, outV)
+		require.Equal(t, mtA, outM)
+		require.False(t, rz)
+	})
+
+	t.Run("num_virtual_cpus drives, changed -> machine_type unknown", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(v8, nullS, v4, mtA, true)
+		require.Equal(t, v8, outV)
+		require.True(t, outM.IsUnknown())
+		require.True(t, rz)
+	})
+
+	t.Run("num_virtual_cpus drives, unchanged -> machine_type taken by name", func(t *testing.T) {
+		// The state machine_type comes from the same-named region, so a reordered
+		// list resolves to the correct value (mtB here), not a neighbor's.
+		outV, outM, rz := resolveMachinePlan(v8, nullS, v8, mtB, true)
+		require.Equal(t, v8, outV)
+		require.Equal(t, mtB, outM)
+		require.False(t, rz)
+	})
+
+	t.Run("machine_type drives, unchanged -> num_virtual_cpus from state", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(nullI, mtA, v4, mtA, true)
+		require.Equal(t, v4, outV)
+		require.Equal(t, mtA, outM)
+		require.False(t, rz)
+	})
+
+	t.Run("machine_type drives, changed -> num_virtual_cpus unknown", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(nullI, mtB, v4, mtA, true)
+		require.True(t, outV.IsUnknown())
+		require.Equal(t, mtB, outM)
+		require.True(t, rz)
+	})
+
+	t.Run("new region (no state) -> sibling unknown", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(v4, nullS, nullI, nullS, false)
+		require.Equal(t, v4, outV)
+		require.True(t, outM.IsUnknown())
+		require.True(t, rz)
+	})
+
+	t.Run("neither set in config -> keep state", func(t *testing.T) {
+		outV, outM, rz := resolveMachinePlan(nullI, nullS, v4, mtA, true)
+		require.Equal(t, v4, outV)
+		require.Equal(t, mtA, outM)
+		require.False(t, rz)
+	})
+}
+
+func TestCoordinateDedicatedMachinePlan(t *testing.T) {
+	v4 := types.Int64Value(4)
+	v8 := types.Int64Value(8)
+	mtSmall := types.StringValue("m6i.xlarge")
+	mtLarge := types.StringValue("m6i.2xlarge")
+	nullI := types.Int64Null()
+	nullS := types.StringNull()
+
+	region := func(name string, vcpus types.Int64, mt types.String) Region {
+		return Region{Name: types.StringValue(name), NumVirtualCpus: vcpus, MachineType: mt}
+	}
+	ded := func(vcpus types.Int64, mt types.String, mem float64) *DedicatedClusterConfig {
+		return &DedicatedClusterConfig{NumVirtualCpus: vcpus, MachineType: mt, MemoryGib: types.Float64Value(mem)}
+	}
+
+	t.Run("homogeneous resize recomputes machine_type and memory", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: ded(v8, nullS, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v8, mtSmall, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.Equal(t, int64(8), plan.DedicatedConfig.NumVirtualCpus.ValueInt64())
+		require.True(t, plan.DedicatedConfig.MachineType.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
+	})
+
+	t.Run("homogeneous no-op leaves the plan untouched", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: ded(v4, nullS, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", nullI, nullS)}}
+
+		require.False(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.Equal(t, mtSmall, plan.DedicatedConfig.MachineType)
+		require.Equal(t, float64(8), plan.DedicatedConfig.MemoryGib.ValueFloat64())
+	})
+
+	t.Run("heterogeneous per-region resize recomputes sibling and aggregates", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: ded(nullI, nullS, 8), Regions: []Region{region("us-east-1", v8, nullS), region("us-east-2", v8, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", v4, mtSmall), region("us-east-2", v8, mtLarge)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", v8, mtSmall), region("us-east-2", v8, mtLarge)}}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.True(t, plan.Regions[0].MachineType.IsUnknown()) // resized region's sibling
+		require.Equal(t, mtLarge, plan.Regions[1].MachineType)   // unchanged region kept
+		require.True(t, plan.DedicatedConfig.NumVirtualCpus.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MachineType.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
+	})
+
+	t.Run("heterogeneous reorder corrects machine_type by name", func(t *testing.T) {
+		// Same region set, reordered. The index-wise plan modifiers carried the
+		// neighbor's machine_type; coordination must correct each by name and NOT
+		// treat this as a resize.
+		config := &CockroachCluster{DedicatedConfig: ded(nullI, nullS, 8), Regions: []Region{region("us-east-2", v8, nullS), region("us-east-1", v4, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", v4, mtSmall), region("us-east-2", v8, mtLarge)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-2", v8, mtSmall), region("us-east-1", v4, mtLarge)}}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.Equal(t, mtLarge, plan.Regions[0].MachineType)       // us-east-2 corrected
+		require.Equal(t, mtSmall, plan.Regions[1].MachineType)       // us-east-1 corrected
+		require.False(t, plan.DedicatedConfig.MemoryGib.IsUnknown()) // not a resize
+	})
+
+	t.Run("heterogeneous removal recomputes cluster-wide aggregates", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: ded(nullI, nullS, 8), Regions: []Region{region("us-east-2", v8, nullS), region("us-west-2", v4, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v8, mtLarge, 16), Regions: []Region{region("us-east-1", v8, mtLarge), region("us-east-2", v8, mtLarge), region("us-west-2", v4, mtSmall)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v8, mtLarge, 16), Regions: []Region{region("us-east-2", v8, mtLarge), region("us-west-2", v4, mtSmall)}}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.True(t, plan.DedicatedConfig.NumVirtualCpus.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MachineType.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
+	})
+
+	t.Run("switch heterogeneous to cluster-wide clears per-region fields", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: ded(v8, nullS, 8), Regions: []Region{region("us-east-1", nullI, nullS), region("us-east-2", nullI, nullS)}}
+		state := &CockroachCluster{DedicatedConfig: ded(v4, mtSmall, 8), Regions: []Region{region("us-east-1", v4, mtSmall), region("us-east-2", v8, mtLarge)}}
+		plan := &CockroachCluster{DedicatedConfig: ded(v8, mtSmall, 8), Regions: []Region{region("us-east-1", v4, mtSmall), region("us-east-2", v8, mtLarge)}}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.True(t, plan.Regions[0].NumVirtualCpus.IsNull())
+		require.True(t, plan.Regions[0].MachineType.IsNull())
+		require.True(t, plan.Regions[1].NumVirtualCpus.IsNull())
+		require.True(t, plan.Regions[1].MachineType.IsNull())
+		require.Equal(t, int64(8), plan.DedicatedConfig.NumVirtualCpus.ValueInt64())
+		require.True(t, plan.DedicatedConfig.MachineType.IsUnknown())
+		require.True(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
 	})
 }
 

--- a/internal/provider/cmek_resource.go
+++ b/internal/provider/cmek_resource.go
@@ -34,6 +34,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 )
 
+// cmekRegionSchema is the cluster resource's regionSchema without the per-region
+// machine type fields (num_virtual_cpus/machine_type). Those are managed on the
+// cockroach_cluster resource; the CMEK resource neither sends nor reads them, so
+// exposing them on additional_regions would be misleading. Derived from
+// regionSchema so the remaining shared fields stay in sync.
+var cmekRegionSchema = func() schema.NestedAttributeObject {
+	attrs := make(map[string]schema.Attribute, len(regionSchema.Attributes))
+	for name, attr := range regionSchema.Attributes {
+		if name == "num_virtual_cpus" || name == "machine_type" {
+			continue
+		}
+		attrs[name] = attr
+	}
+	return schema.NestedAttributeObject{Attributes: attrs}
+}()
+
 var cmekAttributes = map[string]schema.Attribute{
 	"id": schema.StringAttribute{
 		Required:            true,
@@ -100,7 +116,7 @@ var cmekAttributes = map[string]schema.Attribute{
 		},
 	},
 	"additional_regions": schema.ListNestedAttribute{
-		NestedObject:        regionSchema,
+		NestedObject:        cmekRegionSchema,
 		Optional:            true,
 		MarkdownDescription: "Once CMEK is enabled for a cluster, no new regions can be added to the cluster resource, since they need encryption key info stored in the CMEK resource. New regions can be added and maintained here instead.",
 	},
@@ -136,6 +152,47 @@ func (r *cmekResource) Configure(
 		resp.Diagnostics.AddError("Internal provider error",
 			fmt.Sprintf("Error in Configure: expected %T but got %T", provider{}, req.ProviderData))
 	}
+}
+
+// cmekRegionsToRegions adapts the CMEK additional_regions model to the shared
+// []Region type used by getManagedRegions/reconcileRegionUpdate.
+func cmekRegionsToRegions(regions []CMEKAdditionalRegion) []Region {
+	out := make([]Region, len(regions))
+	for i, r := range regions {
+		out[i] = Region{
+			Name:               r.Name,
+			SqlDns:             r.SqlDns,
+			UiDns:              r.UiDns,
+			InternalDns:        r.InternalDns,
+			PrivateEndpointDns: r.PrivateEndpointDns,
+			NodeCount:          r.NodeCount,
+			Primary:            r.Primary,
+			S3VpcEndpointId:    r.S3VpcEndpointId,
+		}
+	}
+	return out
+}
+
+// regionsToCMEKRegions is the inverse of cmekRegionsToRegions, dropping the
+// per-region machine type fields that the CMEK resource does not manage.
+func regionsToCMEKRegions(regions []Region) []CMEKAdditionalRegion {
+	if regions == nil {
+		return nil
+	}
+	out := make([]CMEKAdditionalRegion, len(regions))
+	for i, r := range regions {
+		out[i] = CMEKAdditionalRegion{
+			Name:               r.Name,
+			SqlDns:             r.SqlDns,
+			UiDns:              r.UiDns,
+			InternalDns:        r.InternalDns,
+			PrivateEndpointDns: r.PrivateEndpointDns,
+			NodeCount:          r.NodeCount,
+			Primary:            r.Primary,
+			S3VpcEndpointId:    r.S3VpcEndpointId,
+		}
+	}
+	return out
 }
 
 func (r *cmekResource) Create(
@@ -271,7 +328,7 @@ func (r *cmekResource) Update(
 		}
 	}
 
-	regionNodes, diags := reconcileRegionUpdate(ctx, state.AdditionalRegions, plan.AdditionalRegions, state.ID.ValueString(), r.provider.service)
+	regionNodes, diags := reconcileRegionUpdate(ctx, cmekRegionsToRegions(state.AdditionalRegions), cmekRegionsToRegions(plan.AdditionalRegions), state.ID.ValueString(), r.provider.service)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -325,7 +382,7 @@ func (r *cmekResource) Update(
 			)
 			return
 		}
-		state.AdditionalRegions = getManagedRegions(&cluster.Regions, plan.AdditionalRegions)
+		state.AdditionalRegions = regionsToCMEKRegions(getManagedRegions(&cluster.Regions, cmekRegionsToRegions(plan.AdditionalRegions), cluster.CloudProvider, &resp.Diagnostics))
 	}
 
 	if len(updateRegions) != 0 {

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -38,6 +38,8 @@ type Region struct {
 	InternalDns        types.String `tfsdk:"internal_dns"`
 	PrivateEndpointDns types.String `tfsdk:"private_endpoint_dns"`
 	NodeCount          types.Int64  `tfsdk:"node_count"`
+	NumVirtualCpus     types.Int64  `tfsdk:"num_virtual_cpus"`
+	MachineType        types.String `tfsdk:"machine_type"`
 	Primary            types.Bool   `tfsdk:"primary"`
 	S3VpcEndpointId    types.String `tfsdk:"s3_vpc_endpoint_id"`
 }
@@ -207,10 +209,25 @@ type CMEKRegion struct {
 }
 
 type ClusterCMEK struct {
-	ID                types.String `tfsdk:"id"`
-	Status            types.String `tfsdk:"status"`
-	Regions           []CMEKRegion `tfsdk:"regions"`
-	AdditionalRegions []Region     `tfsdk:"additional_regions"`
+	ID                types.String           `tfsdk:"id"`
+	Status            types.String           `tfsdk:"status"`
+	Regions           []CMEKRegion           `tfsdk:"regions"`
+	AdditionalRegions []CMEKAdditionalRegion `tfsdk:"additional_regions"`
+}
+
+// CMEKAdditionalRegion mirrors Region for the cockroach_cmek resource's
+// additional_regions, minus the per-region machine type fields
+// (num_virtual_cpus/machine_type), which are managed on the cockroach_cluster
+// resource and have no meaning here.
+type CMEKAdditionalRegion struct {
+	Name               types.String `tfsdk:"name"`
+	SqlDns             types.String `tfsdk:"sql_dns"`
+	UiDns              types.String `tfsdk:"ui_dns"`
+	InternalDns        types.String `tfsdk:"internal_dns"`
+	PrivateEndpointDns types.String `tfsdk:"private_endpoint_dns"`
+	NodeCount          types.Int64  `tfsdk:"node_count"`
+	Primary            types.Bool   `tfsdk:"primary"`
+	S3VpcEndpointId    types.String `tfsdk:"s3_vpc_endpoint_id"`
 }
 
 type ClusterCert struct {


### PR DESCRIPTION
This commit adds the ability to set either num_virtual_cpus or machine_type on individual regions in a cockroach_cluster resource. This feature is not yet fully public, and requires specific access enabled in your Cockroach Cloud organization.

Note, this feature is mutually exclusive with setting dedicated.num_virutal_cpus or dedicated.machine_type. Using both will result in an error.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [x] Acceptance test(s)
- [x] Example(s)
