### PR TITLE
Move enable_sending_queue CHANGELOG entry to [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with each other within a
   region, and must be set on every region when used. Requires a feature flag to be
   enabled on your organization.
+- Added `enable_sending_queue` option to the `groups` block on
+  `cockroach_log_export_config`. When enabled, logs in the group are buffered to a
+  persistent disk-backed queue. Only one group per cluster can have this option
+  enabled. Requires a feature flag to be enabled on your organization.
 
 ### Changed
 
@@ -31,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `enable_sending_queue` option to the `groups` block on `cockroach_log_export_config`. When enabled, logs in the group are buffered to a persistent disk-backed queue, allowing them to survive pod restarts and temporary sink outages. Only one group per cluster can have this option enabled.
 - Added `with_empty_ip_allowlist` option to the `serverless` block on `cockroach_cluster`. Set to `true` to create a serverless cluster with no default IP allowlist entries, requiring explicit allowlist configuration. This is a create-only field and cannot be changed after cluster creation.
 
 ## [1.20.0] - 2026-04-22


### PR DESCRIPTION
## Summary

The `enable_sending_queue` CHANGELOG entry was added under the already-released `[1.21.0]` section, but the feature actually merged to `main` after both the v1.21.0 and v1.21.1 tags were cut — so it shipped in neither release.

This PR relocates the entry from `[1.21.0]` to `[Unreleased] → Added` so it is correctly attributed to the next release. It also reworks the wording to match the surrounding entries' formatting and notes that the feature requires a feature flag.

This change is CHANGELOG-only; the feature code itself is unchanged (already on `main`).

## Test plan

- [x] `git diff main` shows only CHANGELOG.md changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)