### PR TITLE
Make release process discoverable: add RELEASE.md and AGENTS.md

### DIFF
--- a/.github/workflows/pre-release-ci.yaml
+++ b/.github/workflows/pre-release-ci.yaml
@@ -1,4 +1,9 @@
-name: pre-release-ci
+# This workflow is triggered by pushing a "v*" tag (i.e. v1.16.0) and runs the
+# full acceptance test suite against the live CockroachDB Cloud API. It gates
+# the release workflow (release.yml): there is no automated gate, so the
+# release workflow must not be dispatched until this workflow has passed on
+# the tag being released. See RELEASE.md for the full release process.
+name: pre-release-ci (acceptance tests, gates release)
 on:
   push:
     tags:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,30 @@
+# Agent guide
+
+This repository contains `terraform-provider-cockroach`, the
+[Terraform provider](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)
+for the CockroachDB Cloud API. The provider code lives in `internal/provider`,
+with a mocked API client in `mock` used by integration tests.
+
+## Where to look
+
+- **Development setup, debugging, and testing**: [DEVELOPMENT.md](DEVELOPMENT.md)
+- **Release process**: [RELEASE.md](RELEASE.md)
+- **User-facing overview and examples**: [README.md](README.md) and `examples/`
+
+## Key commands
+
+- `make install` — build the provider binary and copy it to your path
+- `make generate` — regenerate the docs under `docs/`
+- `make testacc` — run acceptance tests against the live CockroachDB Cloud API
+  (requires `COCKROACH_API_KEY`; creates real resources)
+
+## Conventions
+
+- The files under `docs/` are generated. Don't edit them by hand — edit the
+  `Description`/`MarkdownDescription` fields in the resource schemas and run
+  `make generate`.
+- Changes should be accompanied by an entry under `[Unreleased]` in
+  `CHANGELOG.md`.
+- Each resource and data source needs both integration tests (mocked API) and
+  acceptance tests (live API). See the Testing section of
+  [DEVELOPMENT.md](DEVELOPMENT.md) for details.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -149,35 +149,7 @@ depends on. Prefer using serverless clusters in tests when possible, since they'
 
 ## Releasing
 
-There's currently no set release cadence. Whenever a couple features and/or bug fixes are ready, we kick off a release.
-
-Before starting a new release, the version should be added to the `CHANGELOG.md` file. Tags should follow [semver](https://semver.org/) semantics with a 'v' prefix, e.g. "v1.0.0". However, the version we use in the change log does not include the 'v'.  The "unreleased" header should be left at the top. For example, the diff will look something like this:
-```
---- a/CHANGELOG.md
-+++ b/CHANGELOG.md
-@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
-
- ## [Unreleased]
-
-+## [1.16.0] - 2026-10-29
-+
- ### Added
-```
-
-Create a PR updating the changelog.  Consider manually running the acceptance tests on the tag PR.  We don't currently require a successful test run for each merge so it's possible any previous commit has broken the tests.  The acceptance tests can be run manually using the [Manually Run Acceptance Tests action](https://github.com/cockroachdb/terraform-provider-cockroach/actions/workflows/acceptance-tests.yml).  Click "Run Workflow" and select the correct branch to run them on.
-
-After the PR updating the changelog is merged down, update your local checkout, tag it with your tag including the 'v' and push the tag.
-Pushing the tag will trigger another set of acceptance tests. For example,
-```
-git pull
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-After the acceptance tests are complete, you'll run the [release action](https://github.com/cockroachdb/terraform-provider-cockroach/actions/workflows/release.yml).  Visit that page, click "Run Workflow" and select the tag you just pushed from the dropdown. The new version should show up on the [Terraform provider registry](https://registry.terraform.io/providers/cockroachdb/cockroach/latest) shortly after. Sometimes it can take up
-to a day or so, but usually it's much quicker.
-
-After a release goes out we customarily post something in our internal [#cc-terraform](https://cockroachlabs.slack.com/archives/C035VTG778F) channel letting internal stakeholders know what was released. Here is an [example](https://cockroachlabs.slack.com/archives/C035VTG778F/p1733863374785779).
+The release process is documented in [RELEASE.md](RELEASE.md).
 
 ## FAQs
 **Q: What's the difference between the plan and the config in create/update requests?**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - [More information about CockroachDB](https://www.cockroachlabs.com/)
 - [More information about Terraform](https://terraform.io)
 
-For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md](DEVELOPMENT.md).
+For information on developing `terraform-provider-cockroach` see [DEVELOPMENT.md](DEVELOPMENT.md). For the release process see [RELEASE.md](RELEASE.md).
 
 ## Reporting Bugs and Requesting Features
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,63 @@
+# Releasing `terraform-provider-cockroach`
+
+This is the canonical runbook for releasing a new version of the provider.
+
+There's currently no set release cadence. Whenever a couple features and/or bug
+fixes are ready, we kick off a release.
+
+Releases are performed by CRL employees with write access to this repository.
+
+## Release steps
+
+1. **Update `CHANGELOG.md`.** Add a version header below the `[Unreleased]`
+   header, moving the unreleased entries under it. The changelog version does
+   **not** include the `v` prefix (git tags do). Versions follow
+   [semver](https://semver.org/) semantics. The `[Unreleased]` header stays at
+   the top. The diff should look like this:
+
+   ```diff
+   --- a/CHANGELOG.md
+   +++ b/CHANGELOG.md
+   @@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
+
+    ## [Unreleased]
+
+   +## [1.16.0] - 2026-10-29
+   +
+    ### Added
+   ```
+
+2. **Open a PR with the changelog change and merge it.** Merges are not gated
+   on acceptance tests, so it's possible a previous commit has broken them.
+   Consider running the
+   [Manually Run Acceptance Tests](https://github.com/cockroachdb/terraform-provider-cockroach/actions/workflows/acceptance-tests.yml)
+   workflow on your branch before merging: click "Run workflow" and select the
+   branch.
+
+3. **Tag the merged commit and push the tag.** The tag includes the `v` prefix:
+
+   ```shell
+   git checkout main
+   git pull
+   git tag v1.16.0
+   git push origin v1.16.0
+   ```
+
+4. **Wait for `pre-release-ci` to pass.** Pushing the tag triggers the
+   [`pre-release-ci`](https://github.com/cockroachdb/terraform-provider-cockroach/actions/workflows/pre-release-ci.yaml)
+   workflow, which runs the full acceptance test suite against the live
+   CockroachDB Cloud API. **There is no automated gate** — verify that
+   `pre-release-ci` has passed on your tag before proceeding to the next step.
+
+5. **Dispatch the release workflow.** Go to the
+   [release action](https://github.com/cockroachdb/terraform-provider-cockroach/actions/workflows/release.yml),
+   click "Run workflow", and select the tag you just pushed from the dropdown.
+   This builds, signs, and publishes the release with GoReleaser.
+
+6. **Confirm the release is published.** The new version should show up on the
+   [Terraform provider registry](https://registry.terraform.io/providers/cockroachdb/cockroach/latest)
+   shortly after — usually within minutes, though it can occasionally take up
+   to a day.
+
+7. **Announce the release.** If you're a CRL employee, post in the internal
+   #cc-terraform Slack channel letting stakeholders know what was released.


### PR DESCRIPTION
## What

Makes the release instructions easier to find and follow — for both humans and coding agents:

- **`RELEASE.md`** (new): dedicated release runbook at the repo root, restructured as a numbered checklist. It names and links the `pre-release-ci` workflow (previously described only as "another set of acceptance tests") and states the manual gate explicitly: the release workflow must not be dispatched until `pre-release-ci` is green on the tag.
- **`AGENTS.md`** (new): a small entry point for coding agents, pointing to `DEVELOPMENT.md` and `RELEASE.md`, listing key make targets, and noting that `docs/` is generated.
- **`README.md`**: links `RELEASE.md` next to the existing `DEVELOPMENT.md` pointer.
- **`DEVELOPMENT.md`**: the `## Releasing` section body is replaced with a link to `RELEASE.md` (the heading stays, so existing anchors keep working).
- **`.github/workflows/pre-release-ci.yaml`**: adds an explanatory header comment and a self-documenting workflow name (`pre-release-ci (acceptance tests, gates release)`), mirroring `release.yml`.

## Why

The release process was buried under a heading in `DEVELOPMENT.md` and could only be found indirectly. The prose also required inference — it never named the `pre-release-ci` workflow, and the manual gate between acceptance tests and the release dispatch was implicit. This moves the steps to a conventionally-named file, cross-links it, and makes the gating explicit.

**Commit checklist**
- [x] Changelog — N/A, docs-only change to contributor/release documentation
- [x] Doc gen (`make generate`) — N/A, no schema changes
- [x] Integration test(s) — N/A
- [x] Acceptance test(s) — N/A
- [x] Example(s) — N/A