### PR TITLE
[CNSL-2430] defer unknown label values during validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added write-only `password_wo` and `password_wo_version` attributes to the `cockroach_sql_user` resource (requires Terraform CLI 1.11+). The password is sent on create and rotation but never persisted in Terraform state. Rotate by changing `password_wo` and incrementing `password_wo_version`.
 
+### Fixed
+
+- Fixed `labels` on `cockroach_cluster` and `cockroach_folder` failing validation
+  when a label value is not known at plan time, such as
+  `labels = { environment = var.environment }`. Unknown values are now skipped
+  during validation and checked once they resolve. Label keys and known values
+  continue to be validated as before.
+
 ## [1.22.0] - 2026-07-16
 
 ### Added

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"regexp"
@@ -4822,6 +4823,126 @@ func getTestClusterWithLabels(
 		}] %s%s
 	}
 	`, folderName, clusterName, labelsString, parentString)
+}
+
+// TestIntegrationClusterWithUnknownLabelValues is an integration test focused
+// only on testing labels whose values aren't known when Terraform validates the
+// configuration. The other label tests build their configuration from quoted
+// string literals, so every value they produce is already known.
+func TestIntegrationClusterWithUnknownLabelValues(t *testing.T) {
+	clusterID := uuid.Nil.String()
+	clusterName := fmt.Sprintf("%s-serverless-%s", tfTestPrefix, GenerateRandomString(2))
+	// environment and cost_center are unknown during validation. team is a
+	// literal, so it's known on the pass that defers the other two.
+	labels := map[string]string{
+		"environment": "test",
+		"cost_center": "12345",
+		"team":        "console",
+	}
+
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	cluster := client.Cluster{
+		Id:               clusterID,
+		Name:             clusterName,
+		CockroachVersion: latestClusterPatchVersion,
+		CloudProvider:    "GCP",
+		State:            "CREATED",
+		Plan:             "STANDARD",
+		Config: client.ClusterConfig{
+			Serverless: &client.ServerlessClusterConfig{
+				UpgradeType: client.UPGRADETYPETYPE_AUTOMATIC,
+				UsageLimits: &client.UsageLimits{
+					ProvisionedVirtualCpus: ptr(int64(2)),
+				},
+				RoutingId: "routing-id",
+			},
+		},
+		Regions: []client.Region{
+			{
+				Name: "us-central1",
+			},
+		},
+		Labels: labels,
+	}
+
+	// Validate CreateCluster receives the resolved label values, rather than only
+	// that validation let the plan through.
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *client.CreateClusterRequest) (*client.Cluster, *http.Response, error) {
+			if sentLabels := req.Spec.GetLabels(); !maps.Equal(sentLabels, labels) {
+				return nil, nil, fmt.Errorf("unexpected labels in create request: %v", sentLabels)
+			}
+			return &cluster, httpOk, nil
+		},
+	)
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).Return(&cluster, httpOk, nil).AnyTimes()
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					traceMessageStep("create cluster with a label value from an input variable")
+				},
+				Config: getTestClusterWithUnknownLabels(
+					clusterName, labels["environment"], labels["cost_center"], labels["team"],
+				),
+				Check: testCheckLabels(serverlessResourceName, labels),
+			},
+		},
+	})
+}
+
+// getTestClusterWithUnknownLabels returns a cluster configuration with two
+// label values that Terraform leaves unknown while it validates the
+// configuration, one from an input variable and one from a resource that
+// doesn't exist yet.
+func getTestClusterWithUnknownLabels(clusterName, environment, costCenter, team string) string {
+	return fmt.Sprintf(`
+	variable "environment" {
+		type    = string
+		default = "%s"
+	}
+
+	# terraform_data.cost_center.output is unknown at plan time because the
+	# resource does not exist yet.
+	resource "terraform_data" "cost_center" {
+		input = "%s"
+	}
+
+	resource "cockroach_cluster" "test" {
+		name           = "%s"
+		cloud_provider = "GCP"
+		plan = "STANDARD"
+		serverless = {
+			usage_limits = {
+				provisioned_virtual_cpus = 2
+			}
+		}
+		regions = [{
+			name = "us-central1"
+		}]
+		labels = {
+			environment = var.environment
+			cost_center = terraform_data.cost_center.output
+			team        = "%s"
+		}
+	}
+	`, environment, costCenter, clusterName, team)
 }
 
 // TestIntegrationClusterExternalStateChange tests that the cluster resource

--- a/internal/validators/labels.go
+++ b/internal/validators/labels.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
+	"strings"
 
-	"github.com/cockroachdb/terraform-provider-cockroach/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 var labelKeyRegex = regexp.MustCompile("^[a-z][a-z0-9_-]*$")
@@ -63,21 +65,47 @@ func (validator labelsValidator) MarkdownDescription(ctx context.Context) string
 }
 
 func (validator labelsValidator) ValidateMap(
-	ctx context.Context, request validator.MapRequest, response *validator.MapResponse,
+	_ context.Context, request validator.MapRequest, response *validator.MapResponse,
 ) {
-	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() || len(request.ConfigValue.Elements()) == 0 {
+	value := request.ConfigValue
+	if value.IsNull() || value.IsUnknown() || len(value.Elements()) == 0 {
 		return
 	}
 
-	value, diags := request.ConfigValue.ToMapValue(ctx)
-	response.Diagnostics.Append(diags...)
+	// A label value is unknown during the validate walk when it references a value
+	// Terraform has not resolved yet, as in `labels = { environment = var.environment }`.
+	// Validators must tolerate unknown values and defer to the walk that runs once
+	// they resolve, rather than failing the whole plan.
+	labels := make(map[string]string, len(value.Elements()))
+	var nullKeys []string
+	for key, elem := range value.Elements() {
+		strVal, ok := elem.(types.String)
+		if !ok {
+			// Only reachable if this validator is attached to a map whose element
+			// type is not a string, which the schema is meant to rule out.
+			response.Diagnostics.Append(validatordiag.BugInProviderDiagnostic(
+				fmt.Sprintf("Labels validator received a non-string value for key %q", key),
+			))
+			return
+		}
+		switch {
+		case strVal.IsNull():
+			nullKeys = append(nullKeys, key)
+			labels[key] = ""
+		case strVal.IsUnknown():
+			labels[key] = ""
+		default:
+			labels[key] = strVal.ValueString()
+		}
+	}
 
-	labels, err := utils.ToStringMap(value)
-	if err != nil {
-		response.Diagnostics.AddError(
-			"Error processing labels",
-			fmt.Sprintf("Could not convert labels: %v", err),
-		)
+	if len(nullKeys) > 0 {
+		sort.Strings(nullKeys)
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			fmt.Sprintf("must not contain null values, but found null for: %s", strings.Join(nullKeys, ", ")),
+			value.String(),
+		))
 	}
 
 	if len(labels) > ResourceLabelLimit {

--- a/internal/validators/labels_test.go
+++ b/internal/validators/labels_test.go
@@ -1,0 +1,155 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLabelsValidator exercises the labels validator directly. The resource
+// level tests build their configuration with quoted string literals, so every
+// label value they produce is known. Unknown values, which is what Terraform
+// supplies for `labels = { environment = var.environment }` during the validate
+// walk, can only be expressed by constructing the attribute values by hand.
+func TestLabelsValidator(t *testing.T) {
+	tooManyLabels := make(map[string]attr.Value, ResourceLabelLimit+1)
+	tooManyUnknownLabels := make(map[string]attr.Value, ResourceLabelLimit+1)
+	for i := 0; i <= ResourceLabelLimit; i++ {
+		tooManyLabels[fmt.Sprintf("key%d", i)] = types.StringValue("value")
+		tooManyUnknownLabels[fmt.Sprintf("key%d", i)] = types.StringUnknown()
+	}
+
+	// The format and limit diagnostics are shared by several cases, so asserting
+	// on their text is what distinguishes "rejected for the right reason" from
+	// "rejected because an unknown value leaked into a check".
+	formatErr := "consist of pairs of keys and optional values"
+	limitErr := fmt.Sprintf("must contain at most %d key-value pairs", ResourceLabelLimit)
+	nullErr := "must not contain null values, but found null for: environment"
+
+	testCases := []struct {
+		name                string
+		labels              types.Map
+		expectedErrContains string
+	}{
+		{
+			name:   "null map",
+			labels: types.MapNull(types.StringType),
+		},
+		{
+			name:   "unknown map",
+			labels: types.MapUnknown(types.StringType),
+		},
+		{
+			name:   "empty map",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{}),
+		},
+		{
+			name: "known values",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringValue("dev"),
+				"team":        types.StringValue("console"),
+			}),
+		},
+		{
+			name: "unknown value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringUnknown(),
+			}),
+		},
+		{
+			name: "null value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringNull(),
+			}),
+			expectedErrContains: nullErr,
+		},
+		{
+			// Only the null key is reported. The unknown one is deferred.
+			name: "null value alongside unknown value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringNull(),
+				"team":        types.StringUnknown(),
+			}),
+			expectedErrContains: nullErr,
+		},
+		{
+			name: "invalid key",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"Environment": types.StringValue("dev"),
+			}),
+			expectedErrContains: formatErr,
+		},
+		{
+			// The key is still checked even though the value is deferred.
+			name: "invalid key with unknown value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"Environment": types.StringUnknown(),
+			}),
+			expectedErrContains: formatErr,
+		},
+		{
+			name: "invalid value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringValue("NOT VALID!"),
+			}),
+			expectedErrContains: formatErr,
+		},
+		{
+			// The known sibling is still checked on this pass.
+			name: "invalid value alongside unknown value",
+			labels: types.MapValueMust(types.StringType, map[string]attr.Value{
+				"environment": types.StringUnknown(),
+				"team":        types.StringValue("NOT VALID!"),
+			}),
+			expectedErrContains: formatErr,
+		},
+		{
+			name:                "above label limit",
+			labels:              types.MapValueMust(types.StringType, tooManyLabels),
+			expectedErrContains: limitErr,
+		},
+		{
+			// Unknown values still count toward the limit.
+			name:                "above label limit with unknown values",
+			labels:              types.MapValueMust(types.StringType, tooManyUnknownLabels),
+			expectedErrContains: limitErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			request := validator.MapRequest{
+				Path:        path.Root("labels"),
+				ConfigValue: tc.labels,
+			}
+			response := &validator.MapResponse{}
+
+			Labels().ValidateMap(context.Background(), request, response)
+
+			if tc.expectedErrContains == "" {
+				require.False(t, response.Diagnostics.HasError(),
+					"unexpected errors: %v", response.Diagnostics.Errors())
+			} else {
+				require.Contains(t, errorDetails(response.Diagnostics), tc.expectedErrContains)
+			}
+		})
+	}
+}
+
+// errorDetails joins the detail of every error diagnostic so a test can assert
+// on why validation failed rather than only on whether it failed.
+func errorDetails(diags diag.Diagnostics) string {
+	details := make([]string, 0, len(diags.Errors()))
+	for _, d := range diags.Errors() {
+		details = append(details, d.Detail())
+	}
+	return strings.Join(details, "\n")
+}


### PR DESCRIPTION
The labels validator guarded against the whole map being null or unknown but not against individual elements being unknown. Terraform supplies unknown values during the validate walk whenever a label references a value it has not resolved yet, so a configuration such as

  labels = { environment = var.environment }

caused utils.ToStringMap to fail and the whole plan to error.

Validate the elements directly instead. Unknown values are deferred to the walk that runs once they resolve, while everything else is still checked on this pass: keys are always known, known sibling values are still format checked, and unknown entries still count toward the label limit. Explicit nulls are already resolved and so remain an error, now with a message naming the offending keys rather than the previous generic conversion failure.

cockroach_cluster and cockroach_folder share this validator, so both are fixed.

Adds unit tests for the validator, which previously had none, and an integration test covering label values that are unknown during validation, sourced both from an input variable and from a resource that does not exist yet. The existing label tests build their configuration from string literals, so every value they produce is known and this path went uncovered.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
