### PR TITLE
[CNSL-2431] reduce cockroach_cluster plan noise on updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped version of cockroach-cloud-sdk-go from v8 to v9.
 
+### Fixed
+
+- Reduced `cockroach_cluster` plan noise: `account_id`, `parent_id`,
+  `delete_protection`, `dedicated.memory_gib`, `dedicated.disk_iops`, and the
+  `regions` block's `ui_dns`, `private_endpoint_dns`, and `s3_vpc_endpoint_id` are
+  no longer reported as "known after apply" on updates that don't change them.
+
 ## [1.22.0] - 2026-07-16
 
 ### Added

--- a/internal/provider/cluster_resource.go
+++ b/internal/provider/cluster_resource.go
@@ -38,6 +38,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
@@ -89,6 +90,9 @@ var regionSchema = schema.NestedAttributeObject{
 		"ui_dns": schema.StringAttribute{
 			Computed:    true,
 			Description: "DNS name used when connecting to the DB Console for the cluster.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"internal_dns": schema.StringAttribute{
 			Computed:    true,
@@ -99,6 +103,9 @@ var regionSchema = schema.NestedAttributeObject{
 		}, "private_endpoint_dns": schema.StringAttribute{
 			Computed:    true,
 			Description: "Domain name of the cluster for the private endpoint connection. This DNS name is used by GCP Private Service Connect to connect to the cluster.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 		"node_count": schema.Int64Attribute{
 			Optional: true,
@@ -125,13 +132,19 @@ var regionSchema = schema.NestedAttributeObject{
 			MarkdownDescription: "Machine type identifier per node in this region, e.g., m6.xlarge, n2-standard-4. Set this (or `num_virtual_cpus`) on every region to create a heterogeneous Advanced cluster. Mutually exclusive with the cluster-wide `dedicated.num_virtual_cpus`/`dedicated.machine_type` and with `num_virtual_cpus` on the same region. This attribute requires a feature flag to be enabled; it is recommended to use `num_virtual_cpus` instead. Valid for Advanced clusters only.",
 		},
 		"primary": schema.BoolAttribute{
-			Optional:    true,
-			Computed:    true,
+			Optional: true,
+			Computed: true,
+			// No UseStateForUnknown: primary is coupled across regions. Marking one
+			// region primary clears the flag on the others server-side, so a region
+			// whose config omits primary can still change value at apply.
 			Description: "Set to true to mark this region as the primary for a serverless cluster. Exactly one region must be primary. Dedicated clusters expect to have no primary region.",
 		},
 		"s3_vpc_endpoint_id": schema.StringAttribute{
 			Computed:    true,
 			Description: "The ID of the AWS S3 VPC gateway endpoint for this region. Used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.",
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.UseStateForUnknown(),
+			},
 		},
 	},
 }
@@ -167,6 +180,9 @@ func (r *clusterResource) Schema(
 			"account_id": schema.StringAttribute{
 				Computed:    true,
 				Description: "The cloud provider account ID that hosts the cluster. Needed for CMEK and other advanced features.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"customer_cloud_account": schema.SingleNestedAttribute{
 				Optional: true,
@@ -313,10 +329,21 @@ func (r *clusterResource) Schema(
 							int64validator.AtLeast(1),
 						},
 						Description: "Number of disk I/O operations per second that are permitted on each node in the cluster. Only configurable for AWS clusters during creation. For GCP and Azure clusters, this value is ignored and the cloud provider default is used. Omit this attribute to use the server-side default based on machine type and storage size. The provisioned value may differ from the requested value.",
+						// When omitted from config the server derives this from the
+						// machine type and storage size. coordinateDedicatedMachinePlan
+						// resets it to unknown when either of those changes.
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"memory_gib": schema.Float64Attribute{
 						Computed:    true,
 						Description: "Memory per node in GiB.",
+						// Derived from the machine type. coordinateDedicatedMachinePlan
+						// resets it to unknown when the plan implies a resize.
+						PlanModifiers: []planmodifier.Float64{
+							float64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"machine_type": schema.StringAttribute{
 						Optional:            true,
@@ -395,11 +422,17 @@ func (r *clusterResource) Schema(
 				Validators: []validator.String{
 					validators.FolderParentID(),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"delete_protection": schema.BoolAttribute{
 				Computed:    true,
 				Optional:    true,
 				Description: "Set to true to enable delete protection on the cluster. If unset, the server chooses the value on cluster creation, and preserves the value on cluster update.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"backup_config": schema.SingleNestedAttribute{
 				Computed:            true,
@@ -1873,6 +1906,22 @@ func coordinateDedicatedMachinePlan(config, plan, state *CockroachCluster) bool 
 			plan.DedicatedConfig.MachineType = types.StringUnknown()
 		}
 		changed = true
+	}
+
+	// disk_iops is Optional: a known value in config is the user's and must be
+	// left alone. Otherwise the server derives it from the machine type and the
+	// storage size, so it must be recomputed on a resize or a storage change.
+	// storage_gib is compared config-to-state because the plan can carry a state
+	// value forward via UseStateForUnknown. An unknown config value counts as a
+	// change, since pinning disk_iops when storage may move risks a failed apply.
+	if config.DedicatedConfig != nil && !IsKnown(config.DedicatedConfig.DiskIops) && state.DedicatedConfig != nil {
+		storageChanged := config.DedicatedConfig.StorageGib.IsUnknown() ||
+			(IsKnown(config.DedicatedConfig.StorageGib) &&
+				!config.DedicatedConfig.StorageGib.Equal(state.DedicatedConfig.StorageGib))
+		if (resizing || storageChanged) && !plan.DedicatedConfig.DiskIops.IsUnknown() {
+			plan.DedicatedConfig.DiskIops = types.Int64Unknown()
+			changed = true
+		}
 	}
 	return changed
 }

--- a/internal/provider/cluster_resource_test.go
+++ b/internal/provider/cluster_resource_test.go
@@ -37,7 +37,10 @@ import (
 	framework_resource "github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/stretchr/testify/require"
 )
 
@@ -4343,6 +4346,63 @@ func TestCoordinateDedicatedMachinePlan(t *testing.T) {
 		require.True(t, plan.DedicatedConfig.MachineType.IsUnknown())
 		require.True(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
 	})
+
+	// disk_iops is derived from the machine type and the storage size. These
+	// subtests cover the storage side. The machine-type side is already covered
+	// by the resize subtests above.
+	dedStorage := func(storage, iops types.Int64) *DedicatedClusterConfig {
+		return &DedicatedClusterConfig{
+			NumVirtualCpus: v4, MachineType: mtSmall, MemoryGib: types.Float64Value(8),
+			StorageGib: storage, DiskIops: iops,
+		}
+	}
+	storage15, storage100 := types.Int64Value(15), types.Int64Value(100)
+	iops300 := types.Int64Value(300)
+	// A fresh slice per use: coordinateDedicatedMachinePlan mutates plan.Regions,
+	// so config, state and plan must not share backing storage.
+	regions := func() []Region { return []Region{region("us-east-1", nullI, nullS)} }
+
+	t.Run("storage change recomputes disk_iops", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: dedStorage(storage100, nullI), Regions: regions()}
+		state := &CockroachCluster{DedicatedConfig: dedStorage(storage15, iops300), Regions: regions()}
+		plan := &CockroachCluster{DedicatedConfig: dedStorage(storage100, iops300), Regions: regions()}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.True(t, plan.DedicatedConfig.DiskIops.IsUnknown())
+		// Not a machine resize, so memory_gib must stay known.
+		require.False(t, plan.DedicatedConfig.MemoryGib.IsUnknown())
+	})
+
+	t.Run("unknown storage in config recomputes disk_iops", func(t *testing.T) {
+		// storage_gib interpolated from a resource that has not been applied yet.
+		// Storage may move, so a pinned disk_iops would risk a failed apply.
+		unknownStorage := types.Int64Unknown()
+		config := &CockroachCluster{DedicatedConfig: dedStorage(unknownStorage, nullI), Regions: regions()}
+		state := &CockroachCluster{DedicatedConfig: dedStorage(storage15, iops300), Regions: regions()}
+		plan := &CockroachCluster{DedicatedConfig: dedStorage(unknownStorage, iops300), Regions: regions()}
+
+		require.True(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.True(t, plan.DedicatedConfig.DiskIops.IsUnknown())
+	})
+
+	t.Run("unchanged storage keeps disk_iops pinned", func(t *testing.T) {
+		config := &CockroachCluster{DedicatedConfig: dedStorage(storage15, nullI), Regions: regions()}
+		state := &CockroachCluster{DedicatedConfig: dedStorage(storage15, iops300), Regions: regions()}
+		plan := &CockroachCluster{DedicatedConfig: dedStorage(storage15, iops300), Regions: regions()}
+
+		require.False(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.Equal(t, int64(300), plan.DedicatedConfig.DiskIops.ValueInt64())
+	})
+
+	t.Run("disk_iops set in config is left alone across a storage change", func(t *testing.T) {
+		iops500 := types.Int64Value(500)
+		config := &CockroachCluster{DedicatedConfig: dedStorage(storage100, iops500), Regions: regions()}
+		state := &CockroachCluster{DedicatedConfig: dedStorage(storage15, iops300), Regions: regions()}
+		plan := &CockroachCluster{DedicatedConfig: dedStorage(storage100, iops500), Regions: regions()}
+
+		require.False(t, coordinateDedicatedMachinePlan(config, plan, state))
+		require.Equal(t, int64(500), plan.DedicatedConfig.DiskIops.ValueInt64())
+	})
 }
 
 func TestSimplifyClusterVersion(t *testing.T) {
@@ -5029,4 +5089,223 @@ func TestByocEqual(t *testing.T) {
 			require.Equal(t, test.want, equal)
 		})
 	}
+}
+
+// TestIntegrationClusterLabelOnlyPlanNoise validates that changing a single label
+// does not report unrelated computed attributes as "known after apply". Every
+// attribute asserted here is server-assigned but stable across an update.
+func TestIntegrationClusterLabelOnlyPlanNoise(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-label-noise-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	region := func(name string) client.Region {
+		return client.Region{
+			Name:            name,
+			NodeCount:       3,
+			SqlDns:          fmt.Sprintf("%s.sql.example.com", name),
+			UiDns:           fmt.Sprintf("%s.ui.example.com", name),
+			InternalDns:     fmt.Sprintf("%s.internal.example.com", name),
+			S3VpcEndpointId: ptr(fmt.Sprintf("vpce-%s", name)),
+		}
+	}
+	cluster := func(labels map[string]string) *client.Cluster {
+		return &client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			AccountId:        ptr("account-12345"),
+			ParentId:         ptr("root"),
+			DeleteProtection: ptr(client.DELETEPROTECTIONSTATETYPE_DISABLED),
+			Labels:           labels,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{
+					MachineType: "m6i.xlarge", NumVirtualCpus: 4, StorageGib: 15, MemoryGib: 8,
+				},
+			},
+			Regions: []client.Region{region("us-east-1"), region("us-west-2")},
+		}
+	}
+
+	before := cluster(map[string]string{"environment": "staging"})
+	after := cluster(map[string]string{"environment": "production"})
+	current := before
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(before, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			current = after
+			return after, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	cfg := func(env string) string {
+		return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = 15, num_virtual_cpus = 4 }
+  regions = [
+    { name = "us-east-1", node_count = 3 },
+    { name = "us-west-2", node_count = 3 },
+  ]
+  labels = { environment = "%s" }
+}
+`, clusterName, minSupportedClusterMajorVersion, env)
+	}
+
+	// Attributes that must stay known in the plan for a label-only change.
+	quietPaths := []tfjsonpath.Path{
+		tfjsonpath.New("account_id"),
+		tfjsonpath.New("parent_id"),
+		tfjsonpath.New("delete_protection"),
+		tfjsonpath.New("regions").AtSliceIndex(0).AtMapKey("sql_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(0).AtMapKey("ui_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(0).AtMapKey("internal_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(0).AtMapKey("private_endpoint_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(0).AtMapKey("s3_vpc_endpoint_id"),
+		tfjsonpath.New("regions").AtSliceIndex(1).AtMapKey("sql_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(1).AtMapKey("ui_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(1).AtMapKey("internal_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(1).AtMapKey("private_endpoint_dns"),
+		tfjsonpath.New("regions").AtSliceIndex(1).AtMapKey("s3_vpc_endpoint_id"),
+	}
+	quietChecks := make([]plancheck.PlanCheck, 0, len(quietPaths))
+	for _, p := range quietPaths {
+		quietChecks = append(quietChecks, plancheck.ExpectKnownValue("cockroach_cluster.test", p, knownvalue.NotNull()))
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{Config: cfg("staging")},
+			{
+				Config: cfg("production"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: quietChecks,
+				},
+			},
+		},
+	})
+}
+
+// TestIntegrationDedicatedClusterStorageResizeDiskIops validates that growing
+// storage_gib marks the server-derived disk_iops unknown, and that memory_gib,
+// which is derived from the machine type alone, stays known.
+func TestIntegrationDedicatedClusterStorageResizeDiskIops(t *testing.T) {
+	clusterName := fmt.Sprintf("%s-storage-iops-%s", tfTestPrefix, GenerateRandomString(3))
+	clusterID := uuid.Nil.String()
+	if os.Getenv(CockroachAPIKey) == "" {
+		os.Setenv(CockroachAPIKey, "fake")
+	}
+
+	ctrl := gomock.NewController(t)
+	s := mock_client.NewMockService(ctrl)
+	defer HookGlobal(&NewService, func(c *client.Client) client.Service {
+		return s
+	})()
+
+	// Same machine type throughout, so memory_gib is stable. Only storage grows,
+	// and the server-derived disk_iops grows with it.
+	cluster := func(storageGib, diskIops int32) *client.Cluster {
+		return &client.Cluster{
+			Id:               clusterID,
+			Name:             clusterName,
+			CockroachVersion: minSupportedClusterPatchVersion,
+			Plan:             client.PLANTYPE_ADVANCED,
+			CloudProvider:    client.CLOUDPROVIDERTYPE_AWS,
+			State:            client.CLUSTERSTATETYPE_CREATED,
+			Config: client.ClusterConfig{
+				Dedicated: &client.DedicatedHardwareConfig{
+					MachineType:    "m6i.xlarge",
+					NumVirtualCpus: 4,
+					MemoryGib:      8,
+					StorageGib:     storageGib,
+					DiskIops:       diskIops,
+				},
+			},
+			Regions: []client.Region{{Name: "us-east-1", NodeCount: 3}},
+		}
+	}
+
+	before := cluster(15, 300)
+	after := cluster(100, 3000)
+	current := before
+
+	s.EXPECT().CreateCluster(gomock.Any(), gomock.Any()).Return(before, nil, nil)
+	s.EXPECT().GetBackupConfiguration(gomock.Any(), clusterID).
+		Return(initialBackupConfig, httpOk, nil).AnyTimes()
+	s.EXPECT().GetCluster(gomock.Any(), clusterID).DoAndReturn(
+		func(_ context.Context, _ string) (*client.Cluster, *http.Response, error) {
+			return current, httpOk, nil
+		}).AnyTimes()
+	s.EXPECT().UpdateCluster(gomock.Any(), clusterID, gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ string, _ *client.UpdateClusterSpecification) (*client.Cluster, *http.Response, error) {
+			current = after
+			return after, httpOk, nil
+		})
+	s.EXPECT().DeleteCluster(gomock.Any(), clusterID).Return(nil, httpOk, nil)
+
+	// disk_iops is deliberately absent from config so the server derives it.
+	cfg := func(storageGib int) string {
+		return fmt.Sprintf(`
+resource "cockroach_cluster" "test" {
+  name              = "%s"
+  cloud_provider    = "AWS"
+  cockroach_version = "%s"
+  dedicated = { storage_gib = %d, num_virtual_cpus = 4 }
+  regions = [{ name = "us-east-1", node_count = 3 }]
+}
+`, clusterName, minSupportedClusterMajorVersion, storageGib)
+	}
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(15),
+				Check:  resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.disk_iops", "300"),
+			},
+			{
+				Config: cfg(100),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						// Derived from storage: must be recomputed.
+						plancheck.ExpectUnknownValue("cockroach_cluster.test",
+							tfjsonpath.New("dedicated").AtMapKey("disk_iops")),
+						// Derived from the machine type only: must stay known.
+						plancheck.ExpectKnownValue("cockroach_cluster.test",
+							tfjsonpath.New("dedicated").AtMapKey("memory_gib"),
+							knownvalue.Float64Exact(8)),
+					},
+				},
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.disk_iops", "3000"),
+					resource.TestCheckResourceAttr("cockroach_cluster.test", "dedicated.storage_gib", "100"),
+				),
+			},
+		},
+	})
 }

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package float64planmodifier provides plan modifiers for types.Float64 attributes.
+package float64planmodifier

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplace returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//
+// Use RequiresReplaceIfConfigured if the resource replacement should
+// only occur if there is a configuration value (ignore unconfigured drift
+// detection changes). Use RequiresReplaceIf if the resource replacement
+// should check provider-defined conditional logic.
+func RequiresReplace() planmodifier.Float64 {
+	return RequiresReplaceIf(
+		func(_ context.Context, _ planmodifier.Float64Request, resp *RequiresReplaceIfFuncResponse) {
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIf returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The given function returns true. Returning false will not unset any
+//     prior resource replacement.
+//
+// Use RequiresReplace if the resource replacement should always occur on value
+// changes. Use RequiresReplaceIfConfigured if the resource replacement should
+// occur on value changes, but only if there is a configuration value (ignore
+// unconfigured drift detection changes).
+func RequiresReplaceIf(f RequiresReplaceIfFunc, description, markdownDescription string) planmodifier.Float64 {
+	return requiresReplaceIfModifier{
+		ifFunc:              f,
+		description:         description,
+		markdownDescription: markdownDescription,
+	}
+}
+
+// requiresReplaceIfModifier is an plan modifier that sets RequiresReplace
+// on the attribute if a given function is true.
+type requiresReplaceIfModifier struct {
+	ifFunc              RequiresReplaceIfFunc
+	description         string
+	markdownDescription string
+}
+
+// Description returns a human-readable description of the plan modifier.
+func (m requiresReplaceIfModifier) Description(_ context.Context) string {
+	return m.description
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m requiresReplaceIfModifier) MarkdownDescription(_ context.Context) string {
+	return m.markdownDescription
+}
+
+// PlanModifyFloat64 implements the plan modification logic.
+func (m requiresReplaceIfModifier) PlanModifyFloat64(ctx context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	// Do not replace on resource creation.
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	ifFuncResp := &RequiresReplaceIfFuncResponse{}
+
+	m.ifFunc(ctx, req, ifFuncResp)
+
+	resp.Diagnostics.Append(ifFuncResp.Diagnostics...)
+	resp.RequiresReplace = ifFuncResp.RequiresReplace
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if_configured.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if_configured.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfConfigured returns a plan modifier that conditionally requires
+// resource replacement if:
+//
+//   - The resource is planned for update.
+//   - The plan and state values are not equal.
+//   - The configuration value is not null.
+//
+// Use RequiresReplace if the resource replacement should occur regardless of
+// the presence of a configuration value. Use RequiresReplaceIf if the resource
+// replacement should check provider-defined conditional logic.
+func RequiresReplaceIfConfigured() planmodifier.Float64 {
+	return RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.Float64Request, resp *RequiresReplaceIfFuncResponse) {
+			if req.ConfigValue.IsNull() {
+				return
+			}
+
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute is configured and changes, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if_func.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/requires_replace_if_func.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceIfFunc is a conditional function used in the RequiresReplaceIf
+// plan modifier to determine whether the attribute requires replacement.
+type RequiresReplaceIfFunc func(context.Context, planmodifier.Float64Request, *RequiresReplaceIfFuncResponse)
+
+// RequiresReplaceIfFuncResponse is the response type for a RequiresReplaceIfFunc.
+type RequiresReplaceIfFuncResponse struct {
+	// Diagnostics report errors or warnings related to this logic. An empty
+	// or unset slice indicates success, with no warnings or errors generated.
+	Diagnostics diag.Diagnostics
+
+	// RequiresReplace should be enabled if the resource should be replaced.
+	RequiresReplace bool
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/use_state_for_unknown.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier/use_state_for_unknown.go
@@ -1,0 +1,55 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64planmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// UseStateForUnknown returns a plan modifier that copies a known prior state
+// value into the planned value. Use this when it is known that an unconfigured
+// value will remain the same after a resource update.
+//
+// To prevent Terraform errors, the framework automatically sets unconfigured
+// and Computed attributes to an unknown value "(known after apply)" on update.
+// Using this plan modifier will instead display the prior state value in the
+// plan, unless a prior plan modifier adjusts the value.
+func UseStateForUnknown() planmodifier.Float64 {
+	return useStateForUnknownModifier{}
+}
+
+// useStateForUnknownModifier implements the plan modifier.
+type useStateForUnknownModifier struct{}
+
+// Description returns a human-readable description of the plan modifier.
+func (m useStateForUnknownModifier) Description(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// MarkdownDescription returns a markdown description of the plan modifier.
+func (m useStateForUnknownModifier) MarkdownDescription(_ context.Context) string {
+	return "Once set, the value of this attribute in state will not change."
+}
+
+// PlanModifyFloat64 implements the plan modification logic.
+func (m useStateForUnknownModifier) PlanModifyFloat64(_ context.Context, req planmodifier.Float64Request, resp *planmodifier.Float64Response) {
+	// Do nothing if there is no state value.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// Do nothing if there is a known planned value.
+	if !req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// Do nothing if there is an unknown configuration value, otherwise interpolation gets messed up.
+	if req.ConfigValue.IsUnknown() {
+		return
+	}
+
+	resp.PlanValue = req.StateValue
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -207,6 +207,7 @@ github.com/hashicorp/terraform-plugin-framework/resource/identityschema
 github.com/hashicorp/terraform-plugin-framework/resource/schema
 github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults
+github.com/hashicorp/terraform-plugin-framework/resource/schema/float64planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier
 github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier


### PR DESCRIPTION
Changing one attribute on an existing cluster reported roughly ten unrelated attributes as "known after apply", burying the real change. The framework marks every Computed attribute with a null config value unknown on each plan, and UseStateForUnknown had been applied to only some of the cluster schema's Computed attributes.

Pin the ones that are stable across an update: account_id, parent_id, delete_protection, dedicated.memory_gib, dedicated.disk_iops, and the regions block's ui_dns, private_endpoint_dns and s3_vpc_endpoint_id.

The two dedicated fields are derived server-side, so each is paired with a reset to unknown in coordinateDedicatedMachinePlan. memory_gib depends on the machine type alone and reuses the existing `resizing` flag; disk_iops depends on the machine type and the storage size, so it gets its own condition. Folding storage into `resizing` would unsettle memory_gib on a pure storage change, reintroducing the noise.

Vendors float64planmodifier; go.mod and go.sum are unchanged.

**Commit checklist**
- [x] Changelog
- [x] Doc gen (`make generate`)
- [x] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
