### PR TITLE
Raise the unit test timeout from 5 to 10 minutes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 	go clean -testcache -i -x
 
 test:
-	go test ./... -v $(TESTARGS) -timeout 5m
+	go test ./... -v $(TESTARGS) -timeout 10m
 
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m -parallel 100


### PR DESCRIPTION
Recent runs have been bumping up against the 5 minute limit and timing out.

**Commit checklist**
- [ ] Changelog
- [ ] Doc gen (`make generate`)
- [ ] Integration test(s)
- [ ] Acceptance test(s)
- [ ] Example(s)
